### PR TITLE
Fix helm release action

### DIFF
--- a/.github/workflows/release_helm.yaml
+++ b/.github/workflows/release_helm.yaml
@@ -20,6 +20,8 @@ jobs:
     - name: Build helm chart and update index
       run: |
         mkdir -p helm/repo
+        helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+        helm dependency update helm/adaptdl
         helm package helm/adaptdl --destination helm/repo
         helm repo index helm/repo
     - name: Commit changes

--- a/helm/adaptdl/Chart.yaml
+++ b/helm/adaptdl/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: adaptdl
 version: 0.1.16
-appVersion: 0.1.16
+appVersion: 0.1.15

--- a/helm/adaptdl/Chart.yaml
+++ b/helm/adaptdl/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: adaptdl
-version: 0.1.15
-appVersion: 0.1.15
+version: 0.1.16
+appVersion: 0.1.16


### PR DESCRIPTION
Adding an external dependency chart `docker-registry` means that the github action to update and release new helm charts needs to be able to pull that external dependency.

This merge requests adds that, and also bumps the chart version to 0.1.16