### PR TITLE
Updates pypi release action to use the public pypi repo

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Release PyPi and Docker Hub Images
+name: Release PyPi Packages
 
 on:
   push:
@@ -30,7 +30,7 @@ jobs:
     - name: Build and push train package
       env:
         TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         export ADAPTDL_VERSION=${GITHUB_REF#"refs/tags/v"}
         cd adaptdl
@@ -40,7 +40,7 @@ jobs:
     - name: Build and push sched package
       env:
         TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         export ADAPTDL_VERSION=${GITHUB_REF#"refs/tags/v"}
         cd sched
@@ -50,7 +50,7 @@ jobs:
     - name: Build and push cli package
       env:
         TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         export ADAPTDL_VERSION=${GITHUB_REF#"refs/tags/v"}
         cd adaptdl_cli


### PR DESCRIPTION
Change the pypi release action to use the non-test pypi secret to push the packages. Removes dangling references to releasing docker hub images via github actions.