### PR TITLE
Add Codecov and coverage badge to readme. 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,3 +53,9 @@ jobs:
         coverage report -m --omit="**/*test.py"
         coverage html --omit="**/*test.py"
         coverage xml --omit="**/*test.py"  -o htmlcov/coverage.xml
+    - name: Upload to CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: htmlcov/coverage.xml
+        name: adaptdl
+        fail_ci_if_error: true # optional (default = false)

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -4,6 +4,8 @@
 .. image:: https://readthedocs.org/projects/adaptdl/badge/?version=latest
   :target: https://adaptdl.readthedocs.io/en/latest/?badge=latest
   :alt: Documentation Status
+.. image:: https://codecov.io/gh/rmfan/adaptdl/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/rmfan/adaptdl
 
 `Documentation <https://adaptdl.readthedocs.org>`_ |
 `Examples <https://github.com/petuum/adaptdl/tree/master/examples>`_

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -2,6 +2,7 @@
   :align: center
 
 .. image:: https://img.shields.io/github/workflow/status/petuum/adaptdl/Test
+  :target: https://github.com/petuum/adaptdl/actions?query=workflow%3ATest
   :alt: GitHub Workflow Status
 .. image:: https://codecov.io/gh/petuum/adaptdl/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/petuum/adaptdl
@@ -9,6 +10,7 @@
   :target: https://adaptdl.readthedocs.io/en/latest/?badge=latest
   :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/adaptdl
+  :target: https://pypi.org/project/adaptdl/
   :alt: PyPI
 
 `Documentation <https://adaptdl.readthedocs.org>`_ |

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -4,8 +4,8 @@
 .. image:: https://readthedocs.org/projects/adaptdl/badge/?version=latest
   :target: https://adaptdl.readthedocs.io/en/latest/?badge=latest
   :alt: Documentation Status
-.. image:: https://codecov.io/gh/rmfan/adaptdl/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/rmfan/adaptdl
+.. image:: https://codecov.io/gh/petuum/adaptdl/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/petuum/adaptdl
 
 `Documentation <https://adaptdl.readthedocs.org>`_ |
 `Examples <https://github.com/petuum/adaptdl/tree/master/examples>`_

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -8,6 +8,8 @@
 .. image:: https://readthedocs.org/projects/adaptdl/badge/?version=latest
   :target: https://adaptdl.readthedocs.io/en/latest/?badge=latest
   :alt: Documentation Status
+.. image:: https://img.shields.io/pypi/v/adaptdl
+  :alt: PyPI
 
 `Documentation <https://adaptdl.readthedocs.org>`_ |
 `Examples <https://github.com/petuum/adaptdl/tree/master/examples>`_

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,11 +1,13 @@
 .. image:: _static/img/AdaptDLHorizLogo.png
   :align: center
 
+.. image:: https://img.shields.io/github/workflow/status/petuum/adaptdl/Test
+  :alt: GitHub Workflow Status
+.. image:: https://codecov.io/gh/petuum/adaptdl/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/petuum/adaptdl
 .. image:: https://readthedocs.org/projects/adaptdl/badge/?version=latest
   :target: https://adaptdl.readthedocs.io/en/latest/?badge=latest
   :alt: Documentation Status
-.. image:: https://codecov.io/gh/petuum/adaptdl/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/petuum/adaptdl
 
 `Documentation <https://adaptdl.readthedocs.org>`_ |
 `Examples <https://github.com/petuum/adaptdl/tree/master/examples>`_


### PR DESCRIPTION
Integrate Codecov reporting with the existing pytest-cov for unit tests. Adds a coverage badge to the readme based off of the master branch's coverage report