### PR TITLE
change adaptdl docker image to adaptdl-sched

### DIFF
--- a/helm/adaptdl/values.yaml
+++ b/helm/adaptdl/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: petuum/adaptdl
+  repository: petuum/adaptdl-sched
   # Image tag, overrides default value of .Chart.AppVersion if specified.
   tag: null
   # Image digest, used instead of image tag if specified.


### PR DESCRIPTION
Changes the name of the docker image used by the scheduler