### PR TITLE
Adaptdl registry

### DIFF
--- a/adaptdl_cli/adaptdl_cli/registry.py
+++ b/adaptdl_cli/adaptdl_cli/registry.py
@@ -54,11 +54,17 @@ def _get_node_ip():
 def fix_etc_hosts():
     # Correct /etc/hosts entry with the current node IP kubectl is pointing to
     node_ip = _get_node_ip()
+    host_entry = None
     if not node_ip:
         raise SystemExit("Didn't find any nodes.")
-    if node_ip != socket.gethostbyname(ADAPTDL_REGISTRY_URL.split(':')[0]):
+    try:
+        host_entry = socket.gethostbyname(ADAPTDL_REGISTRY_URL.split(':')[0])
+    except socket.gaierror:
+        pass
+
+    if node_ip != host_entry:
         assert os.system(f"sudo `which hostman` add -f {node_ip} \
-                          {ADAPTDL_REGISTRY_URL.split(':')[0]}") == 0
+                {ADAPTDL_REGISTRY_URL.split(':')[0]}") == 0
 
 
 def _find_entry():

--- a/adaptdl_cli/adaptdl_cli/registry.py
+++ b/adaptdl_cli/adaptdl_cli/registry.py
@@ -14,16 +14,16 @@
 # limitations under the License.
 
 
-import json
-import os
-from pathlib import Path
 import sys
+import os
 import socket
+import json
+import subprocess
+from pathlib import Path
 import kubernetes
 
 
 ADAPTDL_REGISTRY_URL = "adaptdl-registry.remote:32000"
-
 
 if "linux" in sys.platform.lower():
     _DAEMON_FILE = "/etc/docker/daemon.json"
@@ -76,8 +76,8 @@ def fix_etc_hosts():
         pass
 
     if node_ip != host_entry:
-        assert os.system(f"sudo `which hostman` add -f {node_ip} \
-                {ADAPTDL_REGISTRY_URL.split(':')[0]}") == 0
+        subprocess.run(f"sudo `which hostman` add -f {node_ip} \
+                        {ADAPTDL_REGISTRY_URL.split(':')[0]}", shell=True)
 
 
 def _find_entry():
@@ -119,14 +119,14 @@ def fix_local_docker():
     if _fix_daemon_json():
         # restart docker daemon
         if "darwin" in sys.platform.lower():
-            assert os.system(MACOS_DOCKER_RESTART_SCRIPT) == 0
+            subprocess.run(MACOS_DOCKER_RESTART_SCRIPT, shell=True)
         elif "linux" in sys.platform.lower():
-            assert os.system(LINUX_DOCKER_RESTART_SCRIPT) == 0
+            subprocess.run(LINUX_DOCKER_RESTART_SCRIPT, shell=True)
         else:
             print("Restart your docker daemon for changes to take effect.")
 
-    assert os.system(f"docker login -u user -p password \
-                      {ADAPTDL_REGISTRY_URL}") == 0
+    subprocess.run(f"docker login -u user -p password \
+                      {ADAPTDL_REGISTRY_URL}", shell=True)
 
 
 if __name__ == "__main__":

--- a/adaptdl_cli/adaptdl_cli/registry.py
+++ b/adaptdl_cli/adaptdl_cli/registry.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 import sys
 
-ADAPTDL_REGISTRY_URL = "adaptdl-registry.default.svc.cluster.local:31001"
+ADAPTDL_REGISTRY_URL = "adaptdl-registry.remote:32000"
 ADAPTDL_REGISTRY_CREDS = "adaptdl-registry-creds"
 
 _DAEMON_FILE = f"{str(Path.home())}/.docker/daemon.json"
@@ -75,8 +75,10 @@ def _fix_daemon_json():
 
 
 def registry_running():
-    svc = json.loads(subprocess.check_output(['kubectl', 'get', 'svc', '-l',
-                                             'app=docker-registry', '-ojson']))
+    svc = json.loads(subprocess.check_output(['kubectl', 'get', 'svc',
+                                              '-A', '-l',
+                                              'app=docker-registry',
+                                              '-ojson']))
     return len(svc['items']) > 0
 
 

--- a/adaptdl_cli/adaptdl_cli/registry.py
+++ b/adaptdl_cli/adaptdl_cli/registry.py
@@ -108,7 +108,7 @@ def _fix_daemon_json():
 def registry_running():
     v1 = kubernetes.client.CoreV1Api()
     svc = v1.list_service_for_all_namespaces(
-        label_selector="app=docker-registry,release=adaptdl")
+        field_selector="metadata.name=adaptdl-registry")
     return len(svc.items) > 0
 
 
@@ -119,9 +119,9 @@ def fix_local_docker():
     if _fix_daemon_json():
         # restart docker daemon
         if "darwin" in sys.platform.lower():
-            os.system(MACOS_DOCKER_RESTART_SCRIPT) == 0
+            assert os.system(MACOS_DOCKER_RESTART_SCRIPT) == 0
         elif "linux" in sys.platform.lower():
-            os.system(LINUX_DOCKER_RESTART_SCRIPT) == 0
+            assert os.system(LINUX_DOCKER_RESTART_SCRIPT) == 0
         else:
             print("Restart your docker daemon for changes to take effect.")
 

--- a/adaptdl_cli/bin/adaptdl
+++ b/adaptdl_cli/bin/adaptdl
@@ -29,7 +29,7 @@ from adaptdl_cli.pvc import get_storageclass, create_pvc, create_copy_pod
 from adaptdl_cli.tensorboard import TENSORBOARD_PREFIX, \
     add_tensorboard_commands
 from adaptdl_cli.registry import fix_local_docker, fix_etc_hosts, \
-    ADAPTDL_REGISTRY_URL, ADAPTDL_REGISTRY_CREDS
+    ADAPTDL_REGISTRY_URL
 
 
 def _get_registry_info():
@@ -40,7 +40,7 @@ def _get_registry_info():
             os.environ['ADAPTDL_SUBMIT_REPO_CREDS'], False
     else:
         print(f"Using AdaptDL internal registry at {ADAPTDL_REGISTRY_URL}")
-        return ADAPTDL_REGISTRY_URL, ADAPTDL_REGISTRY_CREDS, True
+        return ADAPTDL_REGISTRY_URL, None, True
 
 
 def _prefix(image):
@@ -48,8 +48,10 @@ def _prefix(image):
     parts = image.split('/')
     return '/'.join(parts[:-1] + [parts[-1].split(':')[0]])
 
+
 def _replace_localhost(repodigest):
     return ":".join(["localhost"] + repodigest.split(':')[1:])
+
 
 def submit(args, remaining):
     repo, secret, internal = _get_registry_info()
@@ -92,8 +94,9 @@ def submit(args, remaining):
     resource["spec"]["template"]["spec"]["containers"][0]["image"] = \
         _replace_localhost(repodigest) if internal else repodigest
     resource["spec"]["template"]["spec"]["containers"][0]["args"] = remaining
-    resource["spec"]["template"]["spec"]["imagePullSecrets"] = \
-            [{"name": secret}]
+    if secret:
+        resource["spec"]["template"]["spec"]["imagePullSecrets"] = \
+                [{"name": secret}]
 
     if args.name is not None:
         resource["metadata"]["generateName"] = args.name + "-"

--- a/adaptdl_cli/bin/adaptdl
+++ b/adaptdl_cli/bin/adaptdl
@@ -39,7 +39,7 @@ def _get_registry_info():
         return os.environ['ADAPTDL_SUBMIT_REPO'], \
             os.environ['ADAPTDL_SUBMIT_REPO_CREDS'], False
     else:
-        print("Using AdaptDL internal registry")
+        print(f"Using AdaptDL internal registry at {ADAPTDL_REGISTRY_URL}")
         return ADAPTDL_REGISTRY_URL, ADAPTDL_REGISTRY_CREDS, True
 
 
@@ -48,6 +48,8 @@ def _prefix(image):
     parts = image.split('/')
     return '/'.join(parts[:-1] + [parts[-1].split(':')[0]])
 
+def _replace_localhost(repodigest):
+    return ":".join(["localhost"] + repodigest.split(':')[1:])
 
 def submit(args, remaining):
     repo, secret, internal = _get_registry_info()
@@ -85,7 +87,7 @@ def submit(args, remaining):
         ["kubectl", "create", "--dry-run", "-f", jobfile, "-o", "json"])
     resource = json.loads(resource.decode())
     resource["spec"]["template"]["spec"]["containers"][0]["image"] = \
-        repodigest
+        _replace_localhost(repodigest) if internal else repodigest
     resource["spec"]["template"]["spec"]["containers"][0]["args"] = remaining
     resource["spec"]["template"]["spec"]["imagePullSecrets"] = \
             [{"name": secret}]

--- a/adaptdl_cli/bin/adaptdl
+++ b/adaptdl_cli/bin/adaptdl
@@ -28,8 +28,8 @@ from datetime import datetime
 from adaptdl_cli.pvc import get_storageclass, create_pvc, create_copy_pod
 from adaptdl_cli.tensorboard import TENSORBOARD_PREFIX, \
     add_tensorboard_commands
-from adaptdl_cli.registry import fix_local_docker, ADAPTDL_REGISTRY_URL, \
-    ADAPTDL_REGISTRY_CREDS
+from adaptdl_cli.registry import fix_local_docker, fix_etc_hosts, \
+    ADAPTDL_REGISTRY_URL, ADAPTDL_REGISTRY_CREDS
 
 
 def _get_registry_info():
@@ -62,6 +62,9 @@ def submit(args, remaining):
     subprocess.check_call(["docker", "build", "-t", image, args.project] +
                           ([] if not args.dockerfile else
                               ["-f", args.dockerfile]))
+    if internal:
+        # Quick check and fix host entry if it's stale
+        fix_etc_hosts()
     try:
         subprocess.check_call(["docker", "push", image])
     except subprocess.CalledProcessError:

--- a/deploy/eks/adaptdl-eks-cluster-on-demand.yaml
+++ b/deploy/eks/adaptdl-eks-cluster-on-demand.yaml
@@ -12,8 +12,6 @@ nodeGroups:
     maxSize: 4
     minSize: 1
     desiredCapacity: 1
-    preBootstrapCommands:
-      - sudo sh -c "echo '127.0.0.1 adaptdl-registry.default.svc.cluster.local' >> /etc/hosts"
     iam:
       withAddonPolicies:
         autoScaler: true

--- a/docs/installation/deploy-eks.rst
+++ b/docs/installation/deploy-eks.rst
@@ -113,7 +113,7 @@ need help from your AWS administrator to perform this step.
    'StackResources[?LogicalResourceId == `SG`].[PhysicalResourceId]' --output text)
 
    aws ec2 authorize-security-group-ingress --group-id $SECURITY_GROUP \
-   --protocol tcp --port 31001 --cidr 0.0.0.0/0
+   --protocol tcp --port 32000 --cidr 0.0.0.0/0
 
 Cleaning Up
 -----------

--- a/helm/adaptdl/values.yaml
+++ b/helm/adaptdl/values.yaml
@@ -55,6 +55,8 @@ supervisor:
     port: 8080
     targetPort: 8080
 
+# Some services depend on the specific name of the registry service which is
+# enforced through fullnameOverride.
 docker-registry:
   enabled: false
   fullnameOverride: adaptdl-registry

--- a/helm/adaptdl/values.yaml
+++ b/helm/adaptdl/values.yaml
@@ -60,4 +60,5 @@ docker-registry:
   fullnameOverride: adaptdl-registry
   service:
     type: NodePort
-    nodePort: 31001
+    nodePort: 32000
+    port: 5000


### PR DESCRIPTION
Issues handled by this PR

1. We now use port `32000` for registry service everywhere to gain compatibility with microk8s (which is its default) 

2. For internal registry we patch reponame of the ADL job with `localhost`+suffix so that image can be pulled on the remote hosts without need for any `/etc/hosts` entry change on remote host node. This is applicable to both microk8s and EKS.

3. Handle stale `/etc/hosts` entries.

4. Handle case where registry is deployed in a different namespace 

Fixes #13 
Fixes #14 

