### PR TITLE
Only get allocations from running jobs

### DIFF
--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -107,15 +107,14 @@ class AdaptDLAllocator(object):
         job_infos = {}
         allocations = {}
         for job in job_list["items"]:
-            if ("allocation" in job.get("status", {}) and
-                    job.get("status", {}).get("phase") == "Running"):
+            if job.get("status", {}).get("phase") \
+                    not in ["Pending", "Running", "Starting", "Stopping"]:
+                continue
+            if "allocation" in job.get("status", {}):
                 namespace = job["metadata"]["namespace"]
                 name = job["metadata"]["name"]
                 allocations[namespace, name] = \
                     list(job["status"]["allocation"])
-            if job.get("status", {}).get("phase") \
-                    not in ["Pending", "Running", "Starting", "Stopping"]:
-                continue
             job["spec"]["template"]["spec"] = \
                 set_default_resources(job["spec"]["template"]["spec"])
             resources = get_pod_requests(job["spec"]["template"]["spec"])

--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -107,7 +107,8 @@ class AdaptDLAllocator(object):
         job_infos = {}
         allocations = {}
         for job in job_list["items"]:
-            if "allocation" in job.get("status", {}):
+            if ("allocation" in job.get("status", {}) and
+                    job.get("status", {}).get("phase") == "Running"):
                 namespace = job["metadata"]["namespace"]
                 name = job["metadata"]["name"]
                 allocations[namespace, name] = \


### PR DESCRIPTION
Fix a scheduler bug when a job status is updated as completed but the allocations in status are still there. The scheduler will ignore all allocations of non-running/starting/stopping/pending jobs.