### PR TITLE
Initialize gradient accumulation

### DIFF
--- a/adaptdl/adaptdl/torch/data.py
+++ b/adaptdl/adaptdl/torch/data.py
@@ -147,6 +147,7 @@ class AdaptiveDataLoaderHelper(object):
         adaptdl.checkpoint.load_state(self._state)
         self.batch_size = batch_size
         self.future_exit = None
+        self._gradient_accumulation = False
 
     @property
     def current_index(self):


### PR DESCRIPTION
For examples without batch scaling
```
Traceback (most recent call last):
  File "/root/examples/pytorch-cifar/main.py", line 172, in <module>
    train(epoch)
  File "/root/examples/pytorch-cifar/main.py", line 119, in train
    loss.backward()
  File "/opt/conda/lib/python3.7/site-packages/torch/tensor.py", line 195, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "/opt/conda/lib/python3.7/site-packages/torch/autograd/__init__.py", line 99, in backward
    allow_unreachable=True)  # allow_unreachable flag
  File "/opt/conda/lib/python3.7/site-packages/adaptdl/torch/parallel.py", line 134, in _final_callback
    dataloader.train()
  File "/opt/conda/lib/python3.7/site-packages/adaptdl/torch/data.py", line 239, in train
    self.local_bsz_bounds, self._gradient_accumulation)
AttributeError: 'AdaptiveDataLoaderHelper' object has no attribute '_gradient_accumulation'
```