### PR TITLE
remove duplicated find_packages argument

### DIFF
--- a/adaptdl/setup.py
+++ b/adaptdl/setup.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
             "Operating System :: POSIX :: Linux",
         ],
         packages=setuptools.find_packages(include=["adaptdl",
-                                                   "adaptdl.*",
                                                    "adaptdl.*"]),
         python_requires='>=3.6',
         install_requires=read_requirements("requirements.txt")


### PR DESCRIPTION
`"adaptdl.*"` was included twice in `adaptdl/setup.py`. This pr removes one of those.