### PR TITLE
add speedup ratio comparison

### DIFF
--- a/adaptdl/adaptdl/speedup.py
+++ b/adaptdl/adaptdl/speedup.py
@@ -113,12 +113,18 @@ class SpeedupFunction(object):
         self._mem_speedup[1, 1] = 1.0  # replicas = 1  ==>  speedup = 1
         self._mem_local_bsz[1, 1] = base_batch_size
 
-    def __call__(self, nodes, replicas, return_config=False):
+    def __call__(self, nodes, replicas, return_config=False, local_bsz=None):
         # nodes and replicas must have the same shape, dtype=int
         assert np.shape(nodes) == np.shape(replicas)
         assert np.all(np.less_equal(0, nodes))
         assert np.all(np.less_equal(nodes, replicas))
         assert np.all((nodes > 0) == (replicas > 0))
+
+        # if for querying a speedup for bsz, return the speedup
+        if local_bsz:
+            goodput = self._goodput(nodes, replicas, local_bsz)
+            speedup = goodput / self._base_goodput
+            return speedup
 
         # Remember if original arguments are scalars.
         isscalar = np.isscalar(replicas)

--- a/adaptdl/adaptdl/speedup_test.py
+++ b/adaptdl/adaptdl/speedup_test.py
@@ -251,6 +251,7 @@ def test_query():
                                       replicas, 256) / fun._base_goodput
         assert(isinstance(speedup_query[0], float))
         assert(np.all(speedup_actual == speedup_query))
+
         # multi-node
         speedup, (bsz, steps) = fun(replicas, replicas, return_config=True)
         assert(np.all(bsz >= np.ceil(128 / replicas).astype(int)))

--- a/adaptdl/adaptdl/torch/data.py
+++ b/adaptdl/adaptdl/torch/data.py
@@ -278,10 +278,8 @@ class AdaptiveDataLoaderHelper(object):
             # Autoscale batch size, compute on rank 0 and broadcast.
             speedup_fn = get_speedup_fn()
 
-            # check if batch size  is up
-            is_init = self._current_local_bsz is None
             # if init, use the batch size suggested
-            if is_init:
+            if self._current_local_bsz is None:
                 _, (local_bsz, accumulation_steps) = speedup_fn(
                     adaptdl.env.num_nodes(),
                     adaptdl.env.num_replicas(),

--- a/adaptdl/adaptdl/torch/data.py
+++ b/adaptdl/adaptdl/torch/data.py
@@ -286,9 +286,9 @@ class AdaptiveDataLoaderHelper(object):
                     adaptdl.env.num_nodes(),
                     adaptdl.env.num_replicas(),
                     return_config=True)
-                (self._current_local_bsz, self._accumulation_steps) = \
-                    adaptdl.collective.broadcast((local_bsz,
-                                                  accumulation_steps))
+                self._current_local_bsz = local_bsz
+                self._accumulation_steps = accumulation_steps
+
             # if not first time, we check against the relative speedup
             else:
                 suggest_speedup, (local_bsz, accumulation_steps) = speedup_fn(
@@ -302,14 +302,12 @@ class AdaptiveDataLoaderHelper(object):
             # use only if speedup is significant
                 speedup_to_cur = suggest_speedup / current_speedup
                 if speedup_to_cur > self.speedup_threshold:
-                    (self._current_local_bsz, self._accumulation_steps) = \
-                        adaptdl.collective.broadcast((local_bsz,
-                                                      accumulation_steps))
-                else:
-                    (self._current_local_bsz, self._accumulation_steps) = \
-                        adaptdl.collective.broadcast((
-                            self._current_local_bsz,
-                            self._accumulation_steps))
+                    self._current_local_bsz = local_bsz
+                    self._accumulation_steps = accumulation_steps
+
+        (self._current_local_bsz, self._accumulation_steps) = \
+            adaptdl.collective.broadcast((self._current_local_bsz,
+                                          self._accumulation_steps))
 
         self.is_accumulation_step = self._accumulation_steps != 0
         return self.current_local_bsz

--- a/adaptdl/adaptdl/torch/data.py
+++ b/adaptdl/adaptdl/torch/data.py
@@ -147,6 +147,7 @@ class AdaptiveDataLoaderHelper(object):
         adaptdl.checkpoint.load_state(self._state)
         self.batch_size = batch_size
         self.future_exit = None
+        self._gradient_accumulation = False
         self.speedup_threshold = 1.05
 
     @property

--- a/adaptdl/adaptdl/torch/data.py
+++ b/adaptdl/adaptdl/torch/data.py
@@ -297,7 +297,7 @@ class AdaptiveDataLoaderHelper(object):
                 current_speedup = speedup_fn(adaptdl.env.num_nodes(),
                                              adaptdl.env.num_replicas(),
                                              local_bsz=self.current_local_bsz)
-            # use only if speedup is significant
+                # use only if speedup is significant
                 speedup_to_cur = suggest_speedup / current_speedup
                 if speedup_to_cur > self.speedup_threshold:
                     self._current_local_bsz = local_bsz


### PR DESCRIPTION
Added speedup ratio comparison. If suggest_speedup / current_speedup < 1.05, the batch size will not change. 
Orange is original implementation. Pink is the new feature.
![Capture](https://user-images.githubusercontent.com/28548224/96919036-2f2cde00-1479-11eb-9e92-803b2b29ede7.PNG)
![Capture](https://user-images.githubusercontent.com/28548224/96919062-3b18a000-1479-11eb-8e63-8957cb8742c3.PNG)
![Capture](https://user-images.githubusercontent.com/28548224/96919104-4b307f80-1479-11eb-8e99-d967fcdea562.PNG)
