### PR TITLE
Fixes ncf data download and tensorboard write immediately after reset

### DIFF
--- a/examples/NCF/data_utils.py
+++ b/examples/NCF/data_utils.py
@@ -24,9 +24,9 @@ def download_all(root_path, dataset="ml-1m"):
             urlretrieve(base_url + filename, local_filename)
 
 
-def load_all(root_path, train_rating, test_negative, test_num=100):
+def load_all(root_path, train_rating, test_negative, dataset, test_num=100):
     """ We load all the three file here to save time in each epoch. """
-    download_all(root_path)
+    download_all(root_path, dataset)
     train_data = pd.read_csv(
         train_rating, 
         sep='\t', header=None, names=['user', 'item'], 

--- a/examples/NCF/main.py
+++ b/examples/NCF/main.py
@@ -35,7 +35,7 @@ parser.add_argument("--batch_size",
                     help="batch size for training")
 parser.add_argument("--epochs",
                     type=int,
-                    default=40,
+                    default=20,
                     help="training epoches")
 parser.add_argument("--top_k",
                     type=int,
@@ -105,7 +105,7 @@ NeuMF_model_path = os.path.join(model_path, 'NeuMF.pth')
 
 ############################## PREPARE DATASET ##########################
 train_data, test_data, user_num, item_num, train_mat = \
-    data_utils.load_all(main_path, train_rating, test_negative)
+    data_utils.load_all(main_path, train_rating, test_negative, dataset)
 
 # construct the train and test datasets
 train_dataset = data_utils.NCFData(
@@ -172,11 +172,8 @@ with SummaryWriter(tensorboard_dir) as writer:
             batchsize = train_loader.current_batch_size
             accumulation_steps = train_loader.accumulation_steps
 
-        writer.add_scalar("Throughput/Gain", gain, epoch)
-        writer.add_scalar("Throughput/Global_Batchsize",
-                          batchsize, epoch)
-        writer.add_scalar("Throughput/Accumulation_Steps",
-                          accumulation_steps, epoch)
+        train_loader.to_tensorboard(writer, epoch, tag_prefix="AdaptDL/Data/")
+        network.to_tensorboard(writer, epoch, tag_prefix="AdaptDL/Model/")
 
         network.eval()
         stats = adl.Accumulator()


### PR DESCRIPTION
Moves `current_local_bsz` and `accumulation_steps` to `_AdaptiveDataLoaderState` so they persist across resets. Fixes bugs with the `pinterest-20` dataset in `examples/NCF`.