### PR TITLE
fix timezone format parsing in python3.6

### DIFF
--- a/cli/bin/adaptdl
+++ b/cli/bin/adaptdl
@@ -283,11 +283,12 @@ def ls(args, remaining):
             # fromisoformat does not handle the trailing 'Z'
             start_time = datetime.strptime(v["metadata"]["creationTimestamp"],
                                            "%Y-%m-%dT%H:%M:%SZ")
-            # Timezone with colon cannot be parsed correctly in Python 3.6
-            # see https://stackoverflow.com/questions/30999230
-            def adjust(time):
-                return time[:-3] + time[-2:] \
-                        if len(time) >= 3 and time[-3] == ":" else time
+
+            def adjust(t):
+                # Timezone with colon incorrectly parsed in Python 3.6
+                # see https://stackoverflow.com/questions/30999230
+                return t[:-3] + t[-2:] \
+                        if len(t) >= 3 and t[-3] == ":" else t
 
             current_timestamp = datetime.strptime(
                 adjust(v["status"].get(

--- a/cli/bin/adaptdl
+++ b/cli/bin/adaptdl
@@ -284,8 +284,11 @@ def ls(args, remaining):
             start_time = datetime.strptime(v["metadata"]["creationTimestamp"],
                                            "%Y-%m-%dT%H:%M:%SZ")
             # Timezone with colon cannot be parsed correctly in Python 3.6
-            # see https://stackoverflow.com/questions/30999230/how-to-parse-timezone-with-colon
-            adjust = lambda time: time[:-3]+time[-2:] if len(time)>=3 and time[-3] == ":" else time
+            # see https://stackoverflow.com/questions/30999230
+            def adjust(time):
+                return time[:-3] + time[-2:] \
+                        if len(time) >= 3 and time[-3] == ":" else time
+
             current_timestamp = datetime.strptime(
                 adjust(v["status"].get(
                     "completionTimestamp",

--- a/cli/bin/adaptdl
+++ b/cli/bin/adaptdl
@@ -283,9 +283,13 @@ def ls(args, remaining):
             # fromisoformat does not handle the trailing 'Z'
             start_time = datetime.strptime(v["metadata"]["creationTimestamp"],
                                            "%Y-%m-%dT%H:%M:%SZ")
+            # Timezone with colon cannot be parsed correctly in Python 3.6
+            # see https://stackoverflow.com/questions/30999230/how-to-parse-timezone-with-colon
+            adjust = lambda time: time[:-3]+time[-2:] if len(time)>=3 and time[-3] == ":" else time
             current_timestamp = datetime.strptime(
-                v["status"].get("completionTimestamp",
-                                datetime.now(timezone.utc).isoformat()),
+                adjust(v["status"].get(
+                    "completionTimestamp",
+                    datetime.now(timezone.utc).isoformat())),
                 "%Y-%m-%dT%H:%M:%S.%f%z")
             run_time = current_timestamp.replace(tzinfo=None) \
                 - start_time.replace(tzinfo=None)


### PR DESCRIPTION
Fix timezone format parsing when using python3.6. 

Currently when using Python 3.6, there is a bug in timezone parsing, so  `adaptdl ls` will fail because of this error.

According to https://stackoverflow.com/questions/30999230/how-to-parse-timezone-with-colon ,

adjust the timezone format to fix `adaptdl ls`.

Tested with Python 3.6, 3.7 and 3.8