### PR TITLE
Change pod creation error to cause the AdaptDL job to fail instead of the scheduler pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ NAMESPACE = $(or $(shell kubectl config view --minify -o 'jsonpath={..namespace}
 
 registry:
 	helm status adaptdl-registry || \
-	helm install adaptdl-registry stable/docker-registry \
+	helm install adaptdl-registry center/stable/docker-registry \
 		--set fullnameOverride=adaptdl-registry \
 		--set service.type=NodePort \
 		--set service.nodePort=$(REMOTE_PORT)
@@ -39,7 +39,7 @@ deploy: push .values.yaml
 		--values .values.yaml
 
 delete:
-	helm delete $(RELEASE_NAME)
+	helm delete $(RELEASE_NAME) || \
 	helm delete adaptdl-registry
 
 config: .values.yaml

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ NAMESPACE = $(or $(shell kubectl config view --minify -o 'jsonpath={..namespace}
 
 registry:
 	helm status adaptdl-registry || \
-	helm install adaptdl-registry center/stable/docker-registry \
+	helm install adaptdl-registry stable/docker-registry \
 		--set fullnameOverride=adaptdl-registry \
 		--set service.type=NodePort \
 		--set service.nodePort=$(REMOTE_PORT)

--- a/sched/adaptdl_sched/controller.py
+++ b/sched/adaptdl_sched/controller.py
@@ -142,7 +142,7 @@ class AdaptDLController(object):
                             job["spec"]["template"], allocation,
                             job["status"]["group"], rank)
                 except kubernetes.client.rest.ApiException as e:
-                    LOG.info(f"Failed to create pod for {job_name}"
+                    LOG.info(f"Failed to create pod for {job_name}. "
                              "Setting job status to failed")
                     job["status"]["phase"] = "Failed"
                     job["status"]["reason"] = "PodCreationError"


### PR DESCRIPTION
Fixes #84 

Also makes `make delete` delete the registry even if AdaptDL hasn't been deployed/fails to be deleted.