### PR TITLE
Print exceptions for torch hooks and callbacks

### DIFF
--- a/adaptdl/adaptdl/torch/parallel.py
+++ b/adaptdl/adaptdl/torch/parallel.py
@@ -27,6 +27,7 @@ from torch.nn.parallel import DistributedDataParallel
 
 import adaptdl.checkpoint
 import adaptdl.env
+import adaptdl.utils
 from adaptdl.torch.data import current_dataloader
 from adaptdl.torch.scaling_rules import AdaScale, ScalingRuleBase
 from adaptdl.torch.gradient_noise_scale import GradientNoiseScale
@@ -89,6 +90,7 @@ class AdaptiveDataParallel(DistributedDataParallel):
             self.gns.set_accum_scale(accum_scale)
         return super().forward(*args, **kwargs)
 
+    @adaptdl.utils.print_exc
     def _backward_hook(self, param, grad):
         # This method should be invoked once for each parameter during the
         # backward pass, before gradients are synchronized between replicas.
@@ -100,6 +102,7 @@ class AdaptiveDataParallel(DistributedDataParallel):
         self._final_callback_queued = False
         Variable._execution_engine.queue_callback(self._queue_callback)
 
+    @adaptdl.utils.print_exc
     def _queue_callback(self):
         # This method should be invoked after the entire backward pass. We want
         # to make sure self._final_callback is invoked once, only after all
@@ -113,6 +116,7 @@ class AdaptiveDataParallel(DistributedDataParallel):
         self._final_callback_queued = True
         Variable._execution_engine.queue_callback(self._final_callback)
 
+    @adaptdl.utils.print_exc
     def _final_callback(self):
         # This method should be invoked once for each backward pass, after
         # gradients have been synchronized between each replica.

--- a/adaptdl/adaptdl/utils.py
+++ b/adaptdl/adaptdl/utils.py
@@ -1,0 +1,16 @@
+import functools
+import traceback
+
+
+def print_exc(function):
+    """
+    A decorator that wraps the passed in function and prints any exceptions.
+    """
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        try:
+            return function(*args, **kwargs)
+        except:
+            traceback.print_exc()
+            raise
+    return wrapper

--- a/adaptdl/adaptdl/utils.py
+++ b/adaptdl/adaptdl/utils.py
@@ -1,3 +1,18 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import functools
 import traceback
 

--- a/adaptdl/adaptdl/utils.py
+++ b/adaptdl/adaptdl/utils.py
@@ -10,7 +10,7 @@ def print_exc(function):
     def wrapper(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except:
+        except Exception:
             traceback.print_exc()
             raise
     return wrapper


### PR DESCRIPTION
PyTorch doesn't show the full stack trace for exceptions that happen inside backward hooks and callbacks. This PR adds a decorator that manually catches, prints, and re-raises those exceptions.

Before:
```
Traceback (most recent call last):                                                                                                    
  File "mnist_step_5.py", line 144, in <module>                                                                                       
    main()                                                                                                                            
  File "mnist_step_5.py", line 135, in main                                                                                           
    train(args, model, device, train_loader, optimizer, epoch)                                                                        
  File "mnist_step_5.py", line 46, in train                                                                                           
    loss.backward()                                                                                                                   
  File "/home/aurick.qiao/miniconda3/envs/adaptdl-test/lib/python3.8/site-packages/torch/tensor.py", line 185, in backward            
    torch.autograd.backward(self, gradient, retain_graph, create_graph)                                                               
  File "/home/aurick.qiao/miniconda3/envs/adaptdl-test/lib/python3.8/site-packages/torch/autograd/__init__.py", line 125, in backward 
    Variable._execution_engine.run_backward(                                                                                          
RuntimeError                                                                                                                          
```

After:
```
Traceback (most recent call last):                                                                                                   
  File "/home/aurick.qiao/adaptdl-test/adaptdl/adaptdl/adaptdl/utils.py", line 12, in wrapper                                        
    return function(*args, **kwargs)                                                                                                 
  File "/home/aurick.qiao/adaptdl-test/adaptdl/adaptdl/adaptdl/torch/parallel.py", line 123, in _final_callback                      
    raise Exception("reason for exception")                                                                                          
Exception: reason for exception                                                                                                      
Traceback (most recent call last):                                                                                                   
  File "mnist_step_5.py", line 144, in <module>                                                                                      
    main()                                                                                                                           
  File "mnist_step_5.py", line 135, in main                                                                                          
    train(args, model, device, train_loader, optimizer, epoch)                                                                       
  File "mnist_step_5.py", line 46, in train                                                                                          
    loss.backward()                                                                                                                  
  File "/home/aurick.qiao/miniconda3/envs/adaptdl-test/lib/python3.8/site-packages/torch/tensor.py", line 185, in backward           
    torch.autograd.backward(self, gradient, retain_graph, create_graph)                                                              
  File "/home/aurick.qiao/miniconda3/envs/adaptdl-test/lib/python3.8/site-packages/torch/autograd/__init__.py", line 125, in backward
    Variable._execution_engine.run_backward(                                                                                         
RuntimeError                                                                                                                         
```

Will help with debugging issue #93