### PR TITLE
Adaptive Tune Trial Scheduler

### DIFF
--- a/adaptdl/adaptdl/checkpoint.py
+++ b/adaptdl/adaptdl/checkpoint.py
@@ -111,7 +111,9 @@ def save_all_states():
     """
     if from_ray():
         from ray.tune.trainable import TrainableUtil
-        checkpoint_dir = TrainableUtil.make_checkpoint_dir("/tmp", index=None, override=True)
+        checkpoint_dir = TrainableUtil.make_checkpoint_dir("/tmp",
+                                                           index=None,
+                                                           override=True)
     else:
         checkpoint_dir = checkpoint_path()
     for state in _STATES_TO_NAMES:

--- a/adaptdl/adaptdl/collective.py
+++ b/adaptdl/adaptdl/collective.py
@@ -34,9 +34,9 @@ from .reducer import Reducer, default_reduce_fn
 _REDUCER = None
 
 
-def initialize(master_addr=None, 
+def initialize(master_addr=None,
                master_port=None,
-               replica_rank=adaptdl.env.replica_rank(), 
+               replica_rank=adaptdl.env.replica_rank(),
                num_replicas=adaptdl.env.num_replicas()):
     """
     Initialize this module, must be invoked before calling any other functions.

--- a/adaptdl/adaptdl/collective.py
+++ b/adaptdl/adaptdl/collective.py
@@ -36,8 +36,8 @@ _REDUCER = None
 
 def initialize(master_addr=None,
                master_port=None,
-               replica_rank=adaptdl.env.replica_rank(),
-               num_replicas=adaptdl.env.num_replicas()):
+               replica_rank=None,
+               num_replicas=None):
     """
     Initialize this module, must be invoked before calling any other functions.
     This function will block until it has been invoked from all replicas.
@@ -45,11 +45,18 @@ def initialize(master_addr=None,
     Arguments:
         master_addr: address of the replica with rank 0.
         master_port: free port of the replica with rank 0.
+        replica_rank: rank of the current replica.
+        num_replicas: total number of replicas.
 
     Raises:
         RuntimeError: If this module had already been initialized.
     """
     global _REDUCER
+    if replica_rank is None:
+        replica_rank = adaptdl.env.replica_rank()
+    if num_replicas is None:
+        num_replicas = adaptdl.env.num_replicas()
+
     if _REDUCER is not None:
         raise RuntimeError("{} is already initialized".format(__name__))
     if master_addr is None:
@@ -58,7 +65,8 @@ def initialize(master_addr=None,
         master_port = adaptdl.env.master_port()
     _REDUCER = Reducer(replica_rank,
                        num_replicas,
-                       master_addr, master_port)
+                       master_addr,
+                       master_port)
 
 
 def teardown():

--- a/adaptdl/adaptdl/collective.py
+++ b/adaptdl/adaptdl/collective.py
@@ -34,7 +34,10 @@ from .reducer import Reducer, default_reduce_fn
 _REDUCER = None
 
 
-def initialize(master_addr=None, master_port=None):
+def initialize(master_addr=None, 
+               master_port=None,
+               replica_rank=adaptdl.env.replica_rank(), 
+               num_replicas=adaptdl.env.num_replicas()):
     """
     Initialize this module, must be invoked before calling any other functions.
     This function will block until it has been invoked from all replicas.
@@ -53,8 +56,8 @@ def initialize(master_addr=None, master_port=None):
         master_addr = adaptdl.env.master_addr()
     if master_port is None:
         master_port = adaptdl.env.master_port()
-    _REDUCER = Reducer(adaptdl.env.replica_rank(),
-                       adaptdl.env.num_replicas(),
+    _REDUCER = Reducer(replica_rank,
+                       num_replicas,
                        master_addr, master_port)
 
 

--- a/adaptdl/adaptdl/env.py
+++ b/adaptdl/adaptdl/env.py
@@ -18,7 +18,7 @@ environment variables, or their defaults if unset.
 """
 
 import os
-
+import sys
 
 def checkpoint_path():
     """
@@ -162,3 +162,10 @@ def supervisor_url():
         str: URL of the supervisor, or ``None``.
     """
     return os.getenv("ADAPTDL_SUPERVISOR_URL")
+
+
+def from_ray():
+    """ Returns True if the code is being called from Ray"""
+    # TODO: find a fool-proof way
+    return "ray" in sys.modules
+

--- a/adaptdl/adaptdl/env.py
+++ b/adaptdl/adaptdl/env.py
@@ -167,5 +167,8 @@ def supervisor_url():
 
 def from_ray():
     """ Returns True if the code is being called from Ray"""
-    # TODO: find a fool-proof way
-    return "ray" in sys.modules
+    if "ray" in sys.modules:
+        import ray
+        return ray.is_initialized()
+    else:
+        return False

--- a/adaptdl/adaptdl/env.py
+++ b/adaptdl/adaptdl/env.py
@@ -20,6 +20,7 @@ environment variables, or their defaults if unset.
 import os
 import sys
 
+
 def checkpoint_path():
     """
     Path to the directory used for saving and loading checkpoints. Determined
@@ -168,4 +169,3 @@ def from_ray():
     """ Returns True if the code is being called from Ray"""
     # TODO: find a fool-proof way
     return "ray" in sys.modules
-

--- a/adaptdl/adaptdl/reducer.py
+++ b/adaptdl/adaptdl/reducer.py
@@ -85,7 +85,7 @@ class Reducer(object):
                 if (self._root_port == 0):
                     # waiting for server to get a valid port in local mode
                     raise ConnectionRefusedError
-                logger.info(f"rank {rank} connecting to {root_host} "
+                logger.info(f"rank {rank} of {replicas} connecting to {root_host} "
                             f"on port {self._root_port}")
                 sock.connect((root_host, self._root_port))
             except ConnectionRefusedError:

--- a/adaptdl/adaptdl/reducer.py
+++ b/adaptdl/adaptdl/reducer.py
@@ -85,8 +85,8 @@ class Reducer(object):
                 if (self._root_port == 0):
                     # waiting for server to get a valid port in local mode
                     raise ConnectionRefusedError
-                logger.info(f"rank {rank} of {replicas} connecting to {root_host} "
-                            f"on port {self._root_port}")
+                logger.info(f"rank {rank} of {replicas} connecting to "
+                            f"{root_host} on port {self._root_port}")
                 sock.connect((root_host, self._root_port))
             except ConnectionRefusedError:
                 logger.warning("Could not connect to root, trying again...")

--- a/adaptdl/adaptdl/torch/__init__.py
+++ b/adaptdl/adaptdl/torch/__init__.py
@@ -66,9 +66,10 @@ def init_process_group(backend,
         rank (int, optional): Rank of the current process (it should be a
                               number between 0 and ``world_size``-1).
 
-    If init_method, world_size and rank is NOT provided, AdaptDL will try to
-    infer them through environment variables ADAPTDL_MASTER_ADDR,
-    ADAPTDL_NUM_REPLICAS and ADAPTDL_REPLICA_RANK respectively.
+    If init_method, world_size and rank is NOT provided, typically in the
+    Kubernetes environment, AdaptDL will try to infer them through environment
+    variables ADAPTDL_MASTER_ADDR, ADAPTDL_NUM_REPLICAS and
+    ADAPTDL_REPLICA_RANK respectively.
     """
     if adaptdl.env.from_ray():
         from adaptdl_ray.adaptdl.utils import unique_nodes_pg

--- a/adaptdl/adaptdl/torch/__init__.py
+++ b/adaptdl/adaptdl/torch/__init__.py
@@ -14,6 +14,7 @@
 
 
 import sys
+import os
 if "darwin" in sys.platform.lower():
     # To avoid multiple runs of the model code
     # https://pythonspeed.com/articles/python-multiprocessing/
@@ -69,10 +70,20 @@ def init_process_group(backend,
     infer them through environment variables ADAPTDL_MASTER_ADDR,
     ADAPTDL_NUM_REPLICAS and ADAPTDL_REPLICA_RANK respectively.
     """
+    if adaptdl.env.from_ray():
+        from adaptdl_ray.adaptdl import config
+        assert init_method is not None
+        assert world_size is not None
+        assert rank is not None
+        os.environ["ADAPTDL_NUM_NODES"] = str(len(config.nodes()))
+        os.environ["ADAPTDL_REPLICA_RANK"] = str(rank)
+        os.environ["ADAPTDL_NUM_REPLICAS"] = str(world_size)
+
     url = adaptdl.env.supervisor_url()
     master_port = adaptdl.env.master_port()
     if rank is None:
         rank = adaptdl.env.replica_rank()
+
     if world_size is None:
         world_size = adaptdl.env.num_replicas()
 

--- a/adaptdl/adaptdl/torch/__init__.py
+++ b/adaptdl/adaptdl/torch/__init__.py
@@ -48,11 +48,16 @@ def version_check(version):
 
 
 def init_process_group(backend,
-                       replica_rank=adaptdl.env.replica_rank(),
-                       num_replicas=adaptdl.env.num_replicas(),
+                       replica_rank=None,
+                       num_replicas=None,
                        address=None):
     url = adaptdl.env.supervisor_url()
     master_port = adaptdl.env.master_port()
+    if replica_rank is None:
+        replica_rank = adaptdl.env.replica_rank()
+    if num_replicas is None:
+        num_replicas = adaptdl.env.num_replicas()
+
     if address is not None:
         _, master_addr, master_port = address.split(":")
         master_addr = master_addr[2:]
@@ -85,9 +90,7 @@ def init_process_group(backend,
                                   num_replicas)
 
     # Initialize torch.distributed.
-    torch_port = adaptdl.collective.broadcast(portpicker.pick_unused_port()
-                                              if replica_rank == 0
-                                              else 0)
+    torch_port = adaptdl.collective.broadcast(portpicker.pick_unused_port())
     init_method = "tcp://{}:{}?rank={}&world_size={}".format(
             master_addr, torch_port, replica_rank, num_replicas)
     LOG.info("Initializing torch.distributed using %s", init_method)

--- a/adaptdl/adaptdl/torch/__init__.py
+++ b/adaptdl/adaptdl/torch/__init__.py
@@ -71,11 +71,11 @@ def init_process_group(backend,
     ADAPTDL_NUM_REPLICAS and ADAPTDL_REPLICA_RANK respectively.
     """
     if adaptdl.env.from_ray():
-        from adaptdl_ray.adaptdl import config
+        from adaptdl_ray.adaptdl.utils import unique_nodes_pg
         assert init_method is not None
         assert world_size is not None
         assert rank is not None
-        os.environ["ADAPTDL_NUM_NODES"] = str(len(config.nodes()))
+        os.environ["ADAPTDL_NUM_NODES"] = str(unique_nodes_pg())
         os.environ["ADAPTDL_REPLICA_RANK"] = str(rank)
         os.environ["ADAPTDL_NUM_REPLICAS"] = str(world_size)
 

--- a/adaptdl/adaptdl/torch/__init__.py
+++ b/adaptdl/adaptdl/torch/__init__.py
@@ -47,8 +47,8 @@ def version_check(version):
         return False
 
 
-def init_process_group(backend, 
-                       replica_rank=adaptdl.env.replica_rank(), 
+def init_process_group(backend,
+                       replica_rank=adaptdl.env.replica_rank(),
                        num_replicas=adaptdl.env.num_replicas(),
                        address=None):
     url = adaptdl.env.supervisor_url()
@@ -79,10 +79,13 @@ def init_process_group(backend,
         master_addr = adaptdl.env.master_addr()
 
     # Initialize collective module.
-    adaptdl.collective.initialize(master_addr, master_port, replica_rank, num_replicas)
+    adaptdl.collective.initialize(master_addr,
+                                  master_port,
+                                  replica_rank,
+                                  num_replicas)
 
     # Initialize torch.distributed.
-    torch_port = adaptdl.collective.broadcast(portpicker.pick_unused_port() 
+    torch_port = adaptdl.collective.broadcast(portpicker.pick_unused_port()
                                               if replica_rank == 0
                                               else 0)
     init_method = "tcp://{}:{}?rank={}&world_size={}".format(

--- a/adaptdl/adaptdl/torch/_metrics.py
+++ b/adaptdl/adaptdl/torch/_metrics.py
@@ -126,6 +126,9 @@ def _fit_perf_params():
     state.perf_params = fit_perf_params(num_nodes, num_replicas, atomic_bsz,
                                         accum_step_time, optim_step_time)
 
+def _get_sched_hints():
+    _fit_perf_params()
+    return _metrics_state()
 
 def _report_sched_hints():
     assert adaptdl.env.replica_rank() == 0

--- a/adaptdl/adaptdl/torch/_metrics.py
+++ b/adaptdl/adaptdl/torch/_metrics.py
@@ -126,9 +126,11 @@ def _fit_perf_params():
     state.perf_params = fit_perf_params(num_nodes, num_replicas, atomic_bsz,
                                         accum_step_time, optim_step_time)
 
+
 def _get_sched_hints():
     _fit_perf_params()
     return _metrics_state()
+
 
 def _report_sched_hints():
     assert adaptdl.env.replica_rank() == 0

--- a/adaptdl/adaptdl/torch/_metrics.py
+++ b/adaptdl/adaptdl/torch/_metrics.py
@@ -128,6 +128,9 @@ def _fit_perf_params():
 
 
 def _get_sched_hints():
+    state = _metrics_state()
+    if len(state.profile) == 0:
+        return None
     _fit_perf_params()
     return _metrics_state()
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,13 +13,15 @@ AdaptDL Documentation
 Getting Started
 ---------------
 
-AdaptDL consists of a *Kubernetes job scheduler* and an *adaptive training
-library*. They can be used in two ways:
+AdaptDL consists of a *job scheduler* and an *adaptive training library*. They
+can be used in multiple ways:
 
-1.  Scheduling multiple training jobs on a shared cluster or the cloud
+1.  Scheduling multiple training jobs on a shared Kubernetes cluster or the cloud
     (:doc:`Scheduler Installation<installation/index>`).
 2.  Adapting the batch size and learning rate for a single training job
     (:doc:`Standalone Training<standalone-training>`).
+3.  As a Ray Tune Trial Scheduler
+    (:doc:`Tune Trial Scheduler<ray/tune_tutorial.rst>`).
 
 .. toctree::
    :maxdepth: 2
@@ -31,4 +33,5 @@ library*. They can be used in two ways:
    Command Line Interface<commandline/index.rst>
    AdaptDL with PyTorch<adaptdl-pytorch.rst>
    Standalone Training<standalone-training.rst>
+   Tune Trial Scheduler<ray/tune_tutorial.rst>
    API Reference<api/adaptdl.rst>

--- a/docs/ray/tune_tutorial.rst
+++ b/docs/ray/tune_tutorial.rst
@@ -15,15 +15,10 @@ here <https://docs.ray.io/en/latest/tune/api_docs/trainable.html#distributed-tor
 Setup
 -----
 
-1. Install the Ray nightly package for your platform by following instructions
-   `here
-   <https://docs.ray.io/en/latest/installation.html#daily-releases-nightlies>`_.
+1. Install the required packages
+   `pip install -U adaptdl-ray hyperopt`
 
-2. Install latest `adaptdl`, `adaptdl-ray` and `adaptdl-sched` pip packages.
-
-3. Install HyperOpt.
-
-4. Start the ray cluster.
+2. Start the ray cluster.
 
 
 Incorporating the AdaptDL API
@@ -167,6 +162,7 @@ To run the example, simply run it from command line
 
    $ python3 hyperopt_example.py
 
+   ...
    == Status ==
     Current time: 2021-10-26 12:55:14 (running for 00:04:55.09)
     Memory usage on this node: 2.1/31.2 GiB
@@ -190,4 +186,3 @@ The trial names in the end can be interpreted as
 `AdaptDLTrainable_$num_replicas_$num_restarts_$trial_id`. Trials can expand or
 shrink based on the decisions of the AdaptDL optimizer and this gets reflected
 through their names.
-

--- a/docs/ray/tune_tutorial.rst
+++ b/docs/ray/tune_tutorial.rst
@@ -1,0 +1,193 @@
+=======================================
+Using the Adaptive Tune Trial Scheduler
+=======================================
+
+This is a tutorial on using the AdaptDL as a Tune Trial Scheduler. We'll go
+through an example that uses HyperOpt to tune hyperparameters like the learning
+rate, momentum and initial batch size. The batch size and number of replicas
+will be automatically adjusted by AdaptDL throughout the lifetimes of the
+trials so as to efficiently and fairly share the resources of the Ray cluster.
+
+We'll be relying on the PyTorch `DistributedTrainable` Tune API `documented
+here <https://docs.ray.io/en/latest/tune/api_docs/trainable.html#distributed-torch>`_.
+
+
+Setup
+-----
+
+1. Install the Ray nightly package for your platform by following instructions
+   `here
+   <https://docs.ray.io/en/latest/installation.html#daily-releases-nightlies>`_.
+
+2. Install latest `adaptdl`, `adaptdl-ray` and `adaptdl-sched` pip packages.
+
+3. Install HyperOpt.
+
+4. Start the ray cluster.
+
+
+Incorporating the AdaptDL API
+-----------------------------
+
+In order to make use of the Adaptive functionality, we will need to change the
+trainable to include the AdaptDL API.
+
+We don't change the model definition and test and train functions
+
+.. code-block:: python
+
+  class ConvNet(nn.Module):
+      def __init__(self):
+          super(ConvNet, self).__init__()
+          # In this example, we don't change the model architecture
+          # due to simplicity.
+          self.conv1 = nn.Conv2d(1, 3, kernel_size=3)
+          self.fc = nn.Linear(192, 10)
+
+      def forward(self, x):
+          x = F.relu(F.max_pool2d(self.conv1(x), 3))
+          x = x.view(-1, 192)
+          x = self.fc(x)
+          return F.log_softmax(x, dim=1)
+
+
+  # Change these values if you want the training to run quicker or slower.
+  EPOCH_SIZE = 512
+  TEST_SIZE = 256
+
+
+  def train(model, optimizer, train_loader):
+      device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+      model.train()
+      for batch_idx, (data, target) in enumerate(train_loader):
+          # We set this just for the example to run quickly.
+          if batch_idx * len(data) > EPOCH_SIZE:
+              return
+          data, target = data.to(device), target.to(device)
+          optimizer.zero_grad()
+          output = model(data)
+          loss = F.nll_loss(output, target)
+          loss.backward()
+          optimizer.step()
+
+
+  def test(model, data_loader):
+      device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+      model.eval()
+      correct = 0
+      total = 0
+      with torch.no_grad():
+          for batch_idx, (data, target) in enumerate(data_loader):
+              # We set this just for the example to run quickly.
+              if batch_idx * len(data) > TEST_SIZE:
+                  break
+              data, target = data.to(device), target.to(device)
+              outputs = model(data)
+              _, predicted = torch.max(outputs.data, 1)
+              total += target.size(0)
+              correct += (predicted == target).sum().item()
+          else:
+              return 0
+      return correct / total
+
+The trainable function `train_mnist` needs to change though.
+
+.. code-block:: diff
+
+  +import adaptdl.torch as adl
+  +
+   def train_mnist(config: Dict, checkpoint_dir: Optional[str] = None):
+       # Data Setup
+       mnist_transforms = transforms.Compose(
+           [transforms.ToTensor(),
+            transforms.Normalize((0.1307, ), (0.3081, ))])
+
+  -    train_loader = DataLoader(datasets.MNIST("~/data",
+  +    train_loader = adl.AdaptiveDataLoader(datasets.MNIST("~/data",
+           train=True, download=True, transform=mnist_transforms),
+           batch_size=64,
+           shuffle=True)
+
+  -    test_loader = DataLoader(
+  +    test_loader = adl.AdaptiveDataLoader(
+           datasets.MNIST("~/data", train=False, transform=mnist_transforms),
+           batch_size=64,
+           shuffle=True)
+  @@ -21,8 +23,9 @@
+
+       model = ConvNet()
+       model.to(device)
+  -    model = DistributedDataParallel(model)
+  +    model = adl.AdaptiveDataParallel(model, optimizer)
+
+  -    for i in range(10):
+  +    for epoch in adl.remaining_epochs_until(config.get("epochs", 10)):
+           train(model, optimizer, train_loader)
+           acc = test(model, test_loader)
+           # Send the current training result back to Tune
+
+The changes essentially make the dataloaders and model elastic and restart-safe
+thus adding AdaptDL functionality. Now we need to use the the AdaptDL trial
+scheduler which can actually make decisions based on available cluster
+resources and trial characteristics.
+
+
+.. code-block:: python
+   :emphasize-lines: 17
+
+  ray.init(address="auto")
+
+  trainable_cls = DistributedTrainableCreator(train_mnist)
+
+  space = {
+      "bs": hp.choice("bs", range(64, 1024, 64)),
+      "lr": hp.uniform("lr", 0.01, 0.1),
+      "momentum": hp.uniform("momentum", 0.1, 0.9),
+  }
+
+  hyperopt_search = HyperOptSearch(space, metric="mean_accuracy", mode="max")
+
+  analysis = tune.run(
+      trainable_cls,
+      num_samples=4,  # total trials will be num_samples x points on the grid
+      scheduler=AdaptDLScheduler(),
+      search_alg=hyperopt_search)
+
+We first create a trainable (class) and a search space for HyperOpt. We call
+`tune.run` and pass in `AdaptDLScheduler` as the trial scheduler for all the
+trials. The `AdaptDLScheduler` will first try to use GPUs on the Ray cluster.
+If it finds none, it will use CPUs to run the trials.
+
+Full example can be found at `hyperopt_example.py
+<https://github.com/petuum/adaptdl/ray/adaptdl_ray/examples/hyperopt_example.py>`_.
+
+To run the example, simply run it from command line
+
+.. code-block:: shell
+
+   $ python3 hyperopt_example.py
+
+   == Status ==
+    Current time: 2021-10-26 12:55:14 (running for 00:04:55.09)
+    Memory usage on this node: 2.1/31.2 GiB
+    Using AdaptDL scheduling algorithm.
+    Resources requested: 0/8 CPUs, 0/0 GPUs, 0.0/18.43 GiB heap, 0.0/9.21 GiB objects
+    Result logdir: /tmp
+    Number of trials: 4/4 (4 TERMINATED)
+    +-------------------------------+------------+---------------------+----------+--------+------------------+
+    | Trial name                    | status     | loc                 |      acc |   iter |   total time (s) |
+    |-------------------------------+------------+---------------------+----------+--------+------------------|
+    | AdaptDLTrainable_7_2_cd64740f | TERMINATED | 192.168.1.196:20687 | 0.957576 |    102 |          92.0071 |
+    | AdaptDLTrainable_1_2_cd64740e | TERMINATED | 192.168.1.196:21408 | 0.930804 |    102 |         115.433  |
+    | AdaptDLTrainable_1_2_cd647410 | TERMINATED | 192.168.1.196:21407 | 0.953125 |    102 |          75.8803 |
+    | AdaptDLTrainable_5_2_ceeea272 | TERMINATED | 192.168.1.196:21612 | 0.872396 |    102 |         102.775  |
+    +-------------------------------+------------+---------------------+----------+--------+------------------+
+
+    Best trial config: {'bs': 960, 'epochs': 100, 'lr': 0.010874198064009714, 'momentum': 0.5627724615056127}
+    Best trial mean_accuracy: 0.8723958333333334
+
+The trial names in the end can be interpreted as
+`AdaptDLTrainable_$num_replicas_$num_restarts_$trial_id`. Trials can expand or
+shrink based on the decisions of the AdaptDL optimizer and this gets reflected
+through their names.
+

--- a/docs/ray/tune_tutorial.rst
+++ b/docs/ray/tune_tutorial.rst
@@ -2,11 +2,11 @@
 Using the Adaptive Tune Trial Scheduler
 =======================================
 
-This is a tutorial on using the AdaptDL as a Tune Trial Scheduler. We'll go
-through an example that uses HyperOpt to tune hyperparameters like the learning
-rate, momentum and initial batch size. The batch size and number of replicas
-will be automatically adjusted by AdaptDL throughout the lifetimes of the
-trials so as to efficiently and fairly share the resources of the Ray cluster.
+This is a tutorial on using AdaptDL as a Tune Trial Scheduler. We'll go through
+an example that uses HyperOpt to tune hyperparameters like the learning rate,
+momentum and initial batch size. The batch size and number of replicas will be
+automatically adjusted by AdaptDL throughout the lifetimes of the trials so as
+to efficiently and fairly share the resources of the Ray cluster.
 
 We'll be relying on the PyTorch `DistributedTrainable` Tune API `documented
 here <https://docs.ray.io/en/latest/tune/api_docs/trainable.html#distributed-torch>`_.

--- a/ray/adaptdl_ray/__init__.py
+++ b/ray/adaptdl_ray/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ray/adaptdl_ray/adaptdl/__init__.py
+++ b/ray/adaptdl_ray/adaptdl/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .adaptdl_job_mixin import AdaptDLJobMixin
+from .adaptdl_allocator import AdaptDLAllocator
+
+__all__ = [
+    "AdaptDLAllocator",
+    "AdaptDLJobMixin",
+]

--- a/ray/adaptdl_ray/adaptdl/__init__.py
+++ b/ray/adaptdl_ray/adaptdl/__init__.py
@@ -19,4 +19,5 @@ from .adaptdl_allocator import AdaptDLAllocator
 __all__ = [
     "AdaptDLAllocator",
     "AdaptDLJobMixin",
+    "default_device"
 ]

--- a/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
@@ -39,6 +39,9 @@ class AdaptDLAllocator:
         return [f"{list(self._nodes)[0]}"] * num_devices
 
     def allocate(self, jobs: List[AdaptDLJobMixin], nodes=None):
+        if nodes is None:
+            nodes = self._nodes
+
         assert len(jobs) > 0
         # gather JobInfos
         job_infos = {job.job_id: job.job_info for job in jobs}
@@ -47,7 +50,7 @@ class AdaptDLAllocator:
 
         allocations, desired_nodes = \
                 self._policy.optimize(job_infos, 
-                                      self._nodes, 
+                                      nodes,
                                       prev_allocs, 
                                       self._node_template)
        

--- a/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
@@ -40,7 +40,7 @@ class AdaptDLAllocator:
     @staticmethod
     def _reserve(resources):
         """ Reserve some resources for others """
-        resources["CPU"] -= 1
+        resources["CPU"] -= 1.0
         return resources
 
     def allocate(self, jobs: List[AdaptDLJobMixin]):
@@ -53,4 +53,5 @@ class AdaptDLAllocator:
         allocations, desired_nodes = \
                 self._policy.optimize(job_infos, self._nodes, prev_allocs, self._node_template)
        
+        assert all(v == [] for k, v in allocations.items()) == False
         return allocations, desired_nodes

--- a/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
@@ -53,6 +53,9 @@ class AdaptDLAllocator:
                                       node_infos,
                                       prev_allocs, 
                                       self._node_template)
-       
+        # Fill empty allocations for jobs which didn't get any 
+        for job_id in job_infos:
+            allocations[job_id] = allocations.get(job_id, [])
+
         assert all(v == [] for k, v in allocations.items()) == False
         return allocations, desired_nodes

--- a/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from itertools import cycle
 from typing import Dict, List
 from adaptdl_sched.policy.pollux import PolluxPolicy
 from adaptdl_sched.policy.utils import NodeInfo
@@ -26,14 +27,15 @@ class AdaptDLAllocator:
         self._node_infos = {node['NodeManagerAddress']:
                             NodeInfo(node['Resources'], preemptible=False)
                             for node in nodes}
+        self._default_node = cycle(list(self._node_infos))
         # Add a node template.
         self._node_template = NodeInfo(list(self._node_infos.values())[0].
                                        resources, preemptible=False)
         self._policy = PolluxPolicy()
 
     def default_allocation(self, num_devices=1) -> List[str]:
-        """ Use one device from the first node as default."""
-        return [f"{list(self._node_infos)[0]}"] * num_devices
+        """ Cycle through nodes for default trial allocation."""
+        return [f"{next(self._default_node)}"] * num_devices
 
     def allocate(self,
                  jobs: List[AdaptDLJobMixin],

--- a/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_allocator.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, List, Optional, Union
+from collections import Counter
+from adaptdl.goodput import GoodputFunction, PerfParams, GradParams
+from adaptdl_sched.policy.pollux import PolluxPolicy
+from adaptdl_sched.policy.utils import JobInfo, NodeInfo
+from adaptdl_ray.adaptdl.adaptdl_job_mixin import AdaptDLJobMixin
+
+import ray
+
+
+class AdaptDLAllocator:
+    def __init__(self):
+        nodes = ray.nodes()
+        num_nodes = len(nodes)
+        self._nodes = {node['NodeManagerAddress']: NodeInfo(AdaptDLAllocator._reserve(node['Resources']), 
+                       preemptible=False) for i, node in enumerate(nodes) if node['alive']}
+        # Add a node template.
+        self._node_template = NodeInfo(list(self._nodes.values())[0].resources, preemptible=False)
+        self._policy = PolluxPolicy()
+
+    def default_allocation(self, num_devices=1):
+        """ Use one device from the first node as default."""
+        return [f"{list(self._nodes)[0]}"] * num_devices
+
+    @staticmethod
+    def _reserve(resources):
+        """ Reserve some resources for others """
+        resources["CPU"] -= 1
+        return resources
+
+    def allocate(self, jobs: List[AdaptDLJobMixin]):
+        assert len(jobs) > 0
+        # gather JobInfos
+        job_infos = {job.job_id: job.job_info for job in jobs}
+        # gather previous allocations
+        prev_allocs = {job.job_id: job.allocation for job in jobs}
+
+        allocations, desired_nodes = \
+                self._policy.optimize(job_infos, self._nodes, prev_allocs, self._node_template)
+       
+        return allocations, desired_nodes

--- a/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
@@ -32,7 +32,7 @@ class AdaptDLJobMixin:
         # Be wary of putting large data members here. Tune Experiment checkpointing
         # may try to serialize this.
         self._job_id = kwargs.pop("job_id", 0)
-        self.creation_timestamp = datetime.now()
+        self.creation_timestamp = kwargs.pop("creation_timestamp", datetime.now())
         super().__init__(*args, **kwargs)
 
     @property

--- a/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
@@ -72,8 +72,8 @@ class AdaptDLJobMixin:
     def allocation(self) -> List[str]:
         """ Current allocation the job is utilizing"""
         # Allocation is in use if the job is using it
-        assert self.placement_group_factory is not None
         if self._allocation_in_use():
+            assert self.placement_group_factory is not None
             return pgf_to_allocation(self.placement_group_factory)
         else:
             return []

--- a/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
@@ -16,7 +16,7 @@
 from typing import List
 from datetime import datetime
 
-from adaptdl.goodput import GoodputFunction
+from adaptdl.goodput import GoodputFunction, GradParams
 from adaptdl_sched.policy.speedup import SpeedupFunction
 from adaptdl_sched.policy.utils import JobInfo
 from adaptdl_ray.adaptdl import config
@@ -51,7 +51,10 @@ class AdaptDLJobMixin:
         metrics = self._fetch_metrics()
         if metrics is not None:
             perf_params = metrics.perf_params
-            grad_params = metrics.grad_params
+            if metrics.grad_params is not None:
+                grad_params = metrics.grad_params
+            else:
+                grad_params = GradParams(0.0, 1.0)
             goodput_fn = GoodputFunction(perf_params,
                                          grad_params,
                                          metrics.init_batch_size)

--- a/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
@@ -1,0 +1,104 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, List, Optional, Union
+from datetime import datetime, timedelta
+from collections import Counter
+import logging
+import ray
+from ray import tune
+
+from adaptdl.goodput import GoodputFunction, PerfParams, GradParams
+from adaptdl_sched.policy.speedup import SpeedupFunction
+from adaptdl_sched.policy.utils import JobInfo, NodeInfo
+from typing import Dict, List, Optional, Union
+
+
+class AdaptDLJobMixin:
+    # Job-level replica bounds
+    _MIN_REPLICAS = 0
+    _MAX_REPLICAS = 10
+
+    def __init__(self, *args, **kwargs):
+        # Be wary of putting large data members here. Tune Experiment checkpointing
+        # may try to serialize this.
+        self._job_id = kwargs.pop("job_id", 0)
+        self.creation_timestamp = datetime.now()
+        super().__init__(*args, **kwargs)
+
+    @property
+    def job_id(self):
+        return self._job_id
+
+    def _fetch_metrics(self):
+        """ Returns metrics of this AdaptDLJob."""
+        raise NotImplementedError
+
+    def _allocation_in_use(self) -> bool:
+        """ Returns True if the allocation is being used by an AdaptDLJob."""
+        raise NotImplementedError
+
+    @property
+    def job_info(self):
+        job_resources = {"CPU": 1.0}
+        metrics = self._fetch_metrics()
+        if metrics is not None:
+            perf_params = metrics.perf_params
+            grad_params = metrics.grad_params
+            goodput_fn = GoodputFunction(perf_params, grad_params, 128)
+            speedup_fn = SpeedupFunction(goodput_fn, max_batch_size=1280,
+                                         atomic_bsz_range=(64, 256))
+        else:
+            speedup_fn = lambda n, r: r  # noqa: E731
+
+        return JobInfo(job_resources, speedup_fn, self.creation_timestamp,
+                       AdaptDLJobMixin._MIN_REPLICAS, AdaptDLJobMixin._MAX_REPLICAS)
+
+    @property
+    def allocation(self):
+        # Allocation is in use if the job is using it
+        assert self.placement_group_factory is not None
+        if self._allocation_in_use():
+            return AdaptDLJobMixin.pgf_to_allocation(self.placement_group_factory)
+        else:
+            return []
+
+    @staticmethod
+    def pgf_to_allocation(pgf) -> List[str]:
+        bundles = pgf._bundles[1:]
+        allocs, node_keys, devices_keys = [], [], []
+        for bundle in bundles:
+            node_keys += [k.split(":")[1] for k, v in bundle.items() if k.startswith("node")]
+            devices_keys += [int(v) for k, v in bundle.items() if k == "CPU"]
+
+        for node, devices in zip(node_keys, devices_keys):
+            allocs += [node] * devices
+        return allocs
+
+    @staticmethod
+    def allocation_to_pgf(alloc: List[str]):
+        assert len(alloc) > 0
+        resources = [{"CPU": 0.1}]
+        alloc = Counter(alloc)
+        for node, res in alloc.items():
+            resources.append({"CPU": res, f"node:{node}": 0.01})
+        return tune.PlacementGroupFactory(resources)
+    
+    @staticmethod
+    def _pgf_to_num_replicas(pgf) -> int:
+        # Extract number of CPUs from all PGs
+        return sum(int(bundle.get("CPU", 0)) for bundle in pgf._bundles[1:])
+
+

--- a/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
+++ b/ray/adaptdl_ray/adaptdl/adaptdl_job_mixin.py
@@ -53,7 +53,7 @@ class AdaptDLJobMixin:
             perf_params = metrics.perf_params
             grad_params = metrics.grad_params
             goodput_fn = GoodputFunction(perf_params, grad_params, 128)
-            speedup_fn = SpeedupFunction(goodput_fn, max_batch_size=1280,
+            speedup_fn = SpeedupFunction(goodput_fn, max_batch_size=1280, # TODO
                                          atomic_bsz_range=(64, 256))
         else:
             speedup_fn = lambda n, r: r  # noqa: E731

--- a/ray/adaptdl_ray/adaptdl/config.py
+++ b/ray/adaptdl_ray/adaptdl/config.py
@@ -28,7 +28,7 @@ _JOB_MAX_REPLICAS = 10
 def _avail_nodes() -> Dict:
     """ We return all live nodes with their allocatable resources."""
 
-    alive_nodes = {node["NodeID"] : node for node in ray.nodes() if node["alive"]}
+    alive_nodes = {node["NodeID"] : node for node in sorted(ray.nodes(), key=lambda x:x['NodeID']) if node["alive"]}
     for node_id, resources in ray.state.state._available_resources_per_node().items():
         pruned_resources = defaultdict(float, {k : v for k, v in resources.items() if "group" not in k})
         alive_nodes[node_id]["Resources"] = pruned_resources
@@ -64,7 +64,7 @@ def nodes(consumed_resources: Dict = None) -> List[Dict]:
         node_id_map = {node["NodeID"]: node["NodeManagerAddress"] for node in 
                        ray.nodes() if node["alive"]}
         for node_id, node in avail_nodes.items():
-            resources = consumed_resources[node_id_map[node_id]]
+            resources = consumed_resources.get(node_id_map[node_id], {})
             for resource, amount in resources.items():
                 node["Resources"][resource] += amount
 

--- a/ray/adaptdl_ray/adaptdl/config.py
+++ b/ray/adaptdl_ray/adaptdl/config.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from typing import Dict, List, Optional, Union
+import ray
+
+_DEFAULT_DEVICE = None
+
+# Job-level replica bounds
+_JOB_MIN_REPLICAS = 0
+_JOB_MAX_REPLICAS = 10
+
+
+def _avail_nodes() -> List[Dict]:
+    """ We return all live nodes with their allocatable resources."""
+
+    live_nodes = {node["NodeID"] : node for node in ray.nodes() if node["alive"]}
+    for node_id, resources in ray.state.state._available_resources_per_node().items():
+        pruned_resources = {k : v for k, v in resources.items() if "group" not in k}
+        live_nodes[node_id]["Resources"] = pruned_resources
+    return list(live_nodes.values())
+
+
+def default_device() -> str:
+    """ Default device will be GPU if at least one node has a GPU on it else we
+    use CPUs."""
+
+    global _DEFAULT_DEVICE
+    if _DEFAULT_DEVICE is None:
+        assert ray.is_initialized()
+        if any("GPU" in node['Resources'] for node in _avail_nodes()):
+            _DEFAULT_DEVICE = "GPU"
+        else:
+            _DEFAULT_DEVICE = "CPU"
+    return _DEFAULT_DEVICE
+        
+
+def job_resources():
+    """ Default job resources."""
+
+    return {default_device(): 1, "memory": 1024*1024}
+
+
+def nodes() -> List[Dict]:
+    """Returns all nodes with the default device on them"""
+
+    return [node for node in _avail_nodes() 
+            if default_device() in node["Resources"]]

--- a/ray/adaptdl_ray/adaptdl/config.py
+++ b/ray/adaptdl_ray/adaptdl/config.py
@@ -37,12 +37,12 @@ def _avail_nodes() -> Dict:
     return alive_nodes
 
 
-def default_device() -> str:
+def default_device(refresh=False) -> str:
     """ Default device will be GPU if at least one node has a GPU on it else we
     use CPUs. It is initialized once when the allocator/scheduler is
     instantiated."""
     global _DEFAULT_DEVICE
-    if _DEFAULT_DEVICE is None:
+    if _DEFAULT_DEVICE is None or refresh:
         assert ray.is_initialized()
         if any("GPU" in node['Resources'] for node in _avail_nodes().values()):
             _DEFAULT_DEVICE = "GPU"

--- a/ray/adaptdl_ray/adaptdl/config_test.py
+++ b/ray/adaptdl_ray/adaptdl/config_test.py
@@ -36,11 +36,11 @@ class TrialRunnerTest(unittest.TestCase):
         ray.shutdown()
         self.cluster.shutdown()
 
-    def testResources(self):
+    def testAvailableResources(self):
         assert len(nodes()) == 2
         assert default_device(refresh=True) == "GPU"
 
-    def testFoo(self):
+    def testOthersTakingResources(self):
         # Let someone occupy the head node
         pg = placement_group([{"CPU": 4, "GPU": 1}])
         ray.get(pg.ready())

--- a/ray/adaptdl_ray/adaptdl/config_test.py
+++ b/ray/adaptdl_ray/adaptdl/config_test.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+import ray
+from ray.cluster_utils import Cluster
+from .config import nodes, default_device
+from ray.util.placement_group import placement_group
+
+
+class TrialRunnerTest(unittest.TestCase):
+    def setUp(self):
+        self.cluster = Cluster(
+            initialize_head=True,
+            connect=True,
+            head_node_args={
+                "num_cpus": 4,
+                "num_gpus": 1,
+            })
+        self.cluster.add_node(num_cpus=2, num_gpus=1)
+        self.cluster.wait_for_nodes()
+
+    def tearDown(self):
+        ray.shutdown()
+        self.cluster.shutdown()
+
+    def testResources(self):
+        assert len(nodes()) == 2
+        assert default_device(refresh=True) == "GPU"
+
+    def testFoo(self):
+        # Let someone occupy the head node
+        pg = placement_group([{"CPU": 4, "GPU": 1}])
+        ray.get(pg.ready())
+        # We are left with the second node
+        assert len(nodes()) == 1
+        assert default_device(refresh=True) == "GPU"
+
+        pg = placement_group([{"GPU": 1}])
+        ray.get(pg.ready())
+        # Default device should be CPU
+        assert default_device(refresh=True) == "CPU"
+        assert len(nodes()) == 1

--- a/ray/adaptdl_ray/adaptdl/utils.py
+++ b/ray/adaptdl_ray/adaptdl/utils.py
@@ -19,7 +19,7 @@ from adaptdl_ray.adaptdl import config
 
 
 def pgf_to_allocation(pgf) -> List[str]:
-    """ Convert Placement Groups Factory to AdaptDL allocations"""
+    """ Convert a Placement Groups Factory to AdaptDL allocation"""
     bundles = pgf._bundles[1:]
     allocs, node_keys, num_devices = [], [], []
     for bundle in bundles:
@@ -34,7 +34,7 @@ def pgf_to_allocation(pgf) -> List[str]:
 
 
 def allocation_to_pgf(alloc: List[str]):
-    """ Convert AdaptDL allocations to Placement Group Factory"""
+    """ Convert AdaptDL allocation to a Placement Group Factory"""
     def _construct_bundle(node, device_count):
         resources = {config.default_device(): device_count,
                      f"node:{node}": 0.01}
@@ -53,13 +53,13 @@ def allocation_to_pgf(alloc: List[str]):
 
 
 def pgf_to_num_replicas(pgf) -> int:
-    """ Extract number of replicas of the trial from its PGF"""
+    """ Extract the number of replicas of the trial from its PGF"""
     return sum(int(bundle.get(config.default_device(), 0))
                for bundle in pgf._bundles[1:])
 
 
 def pgs_to_resources(pgs: List[Dict]) -> Dict:
-    """ Returns node-level resource usage by all PGs in pgs."""
+    """ Return node-level resource usage by all PGs in pgs."""
     # Note that every bundle is tagged with the node resource
     resources = defaultdict(Counter)
     for pg in pgs:

--- a/ray/adaptdl_ray/adaptdl/utils.py
+++ b/ray/adaptdl_ray/adaptdl/utils.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional, Union
+from collections import Counter, defaultdict
+from ray import tune
+from adaptdl_ray.adaptdl import config
+
+
+def pgf_to_allocation(pgf) -> List[str]:
+    bundles = pgf._bundles[1:]
+    allocs, node_keys, num_devices = [], [], []
+    for bundle in bundles:
+        node_keys += [k.split(":")[1] for k, v in bundle.items() if k.startswith("node")]
+        num_devices += [int(v) for k, v in bundle.items() if k == config.default_device()]
+
+    for node, count in zip(node_keys, num_devices):
+        allocs += [node] * count
+    return allocs
+
+
+def allocation_to_pgf(alloc: List[str]):
+    def _construct_bundle(node, device_count):
+        resources = {config.default_device(): device_count, 
+                     f"node:{node}": 0.01}
+        if config.default_device() == "GPU":
+            # As per Ray, We need equal amount of CPUs if there are GPUs in
+            # this bundle
+            resources["CPU"] = device_count
+        return resources
+
+    assert len(alloc) > 0
+    resources = [{"CPU": 0.001}]
+    alloc = Counter(alloc)
+    for node, res in alloc.items():
+        resources.append(_construct_bundle(node, res))
+    return tune.PlacementGroupFactory(resources)
+
+
+def pgf_to_num_replicas(pgf) -> int:
+    return sum(int(bundle.get(config.default_device(), 0)) 
+                   for bundle in pgf._bundles[1:])
+
+
+def pgs_to_resources(pgs: List[Dict]) -> Dict:
+    """ Returns node-level resource usage by all PGs in pgs."""
+
+    # Note that every bundle is tagged with the node resource
+    resources = defaultdict(Counter)
+    for pg in pgs:
+        for bundle in pg["bundle_cache"][1:]:
+            # Every bundle has a node resource
+            node_ip = [k.split(":")[1] for k in bundle.keys() if k.startswith("node")][0]
+            for k, v in bundle.items():
+                resources[node_ip][k] += v
+    return resources

--- a/ray/adaptdl_ray/adaptdl/utils.py
+++ b/ray/adaptdl_ray/adaptdl/utils.py
@@ -15,6 +15,7 @@
 from typing import Dict, List
 from collections import Counter, defaultdict
 from ray import tune
+from ray.util.placement_group import get_current_placement_group
 from adaptdl_ray.adaptdl import config
 
 
@@ -70,3 +71,12 @@ def pgs_to_resources(pgs: List[Dict]) -> Dict:
             for k, v in bundle.items():
                 resources[node_ip][k] += v
     return resources
+
+
+def unique_nodes_pg() -> int:
+    nodes = []
+    for bundle in get_current_placement_group().bundle_specs:
+        for resource in bundle:
+            if "node" in resource:
+                nodes.append(resource)
+    return len(set(nodes))

--- a/ray/adaptdl_ray/examples/hyperopt_example.py
+++ b/ray/adaptdl_ray/examples/hyperopt_example.py
@@ -1,0 +1,149 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torchvision import datasets, transforms
+import torch.nn.functional as F
+
+import ray
+from ray import tune
+from ray.tune.integration.torch import DistributedTrainableCreator
+from ray.tune.suggest.hyperopt import HyperOptSearch
+
+import adaptdl.torch as adl
+from adaptdl_ray.tune.adaptdl_trial_sched import AdaptDLScheduler
+
+from hyperopt import hp
+
+# Adapted from https://docs.ray.io/en/latest/tune/tutorials/tune-tutorial.html
+
+
+class ConvNet(nn.Module):
+    def __init__(self):
+        super(ConvNet, self).__init__()
+        # In this example, we don't change the model architecture
+        # due to simplicity.
+        self.conv1 = nn.Conv2d(1, 3, kernel_size=3)
+        self.fc = nn.Linear(192, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 3))
+        x = x.view(-1, 192)
+        x = self.fc(x)
+        return F.log_softmax(x, dim=1)
+
+
+# Change these values if you want the training to run quicker or slower.
+EPOCH_SIZE = 512
+TEST_SIZE = 256
+
+
+def train(model, optimizer, train_loader):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        # We set this just for the example to run quickly.
+        if batch_idx * len(data) > EPOCH_SIZE:
+            return
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+
+
+def test(model, data_loader):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for batch_idx, (data, target) in enumerate(data_loader):
+            # We set this just for the example to run quickly.
+            if batch_idx * len(data) > TEST_SIZE:
+                break
+            data, target = data.to(device), target.to(device)
+            outputs = model(data)
+            _, predicted = torch.max(outputs.data, 1)
+            total += target.size(0)
+            correct += (predicted == target).sum().item()
+        else:
+            return 0
+    return correct / total
+
+
+def train_mnist(config: Dict, checkpoint_dir: Optional[str] = None):
+    # Data Setup
+    mnist_transforms = transforms.Compose(
+        [transforms.ToTensor(),
+         transforms.Normalize((0.1307, ), (0.3081, ))])
+
+    train_loader = adl.AdaptiveDataLoader(datasets.MNIST("~/data", train=True,
+                                          download=True,
+                                          transform=mnist_transforms),
+                                          batch_size=64,
+                                          shuffle=True)
+
+    # Autoscale batch size
+    train_loader.autoscale_batch_size(4096, local_bsz_bounds=(16, 1024))
+
+    test_loader = adl.AdaptiveDataLoader(
+        datasets.MNIST("~/data", train=False, transform=mnist_transforms),
+        batch_size=64,
+        shuffle=True)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model = ConvNet()
+    optimizer = optim.SGD(
+        model.parameters(), lr=config.get("lr", 0.01),
+        momentum=config.get("momentum", 0.79))
+
+    model.to(device)
+    model = adl.AdaptiveDataParallel(model, optimizer)
+
+    for epoch in adl.remaining_epochs_until(config.get("epochs", 10)):
+        train(model, optimizer, train_loader)
+        acc = test(model, test_loader)
+        # Send the current training result back to Tune
+        tune.report(mean_accuracy=acc)
+
+
+ray.init(address="auto")
+
+trainable_cls = DistributedTrainableCreator(train_mnist)
+
+space = {
+    "lr": hp.uniform("lr", 0.01, 0.1),
+    "momentum": hp.uniform("momentum", 0.1, 0.9),
+    "epochs": 100
+}
+
+hyperopt_search = HyperOptSearch(space, metric="mean_accuracy", mode="max")
+
+analysis = tune.run(
+    trainable_cls,
+    num_samples=16,  # total trials will be num_samples x points on the grid
+    scheduler=AdaptDLScheduler(),
+    search_alg=hyperopt_search)
+
+best_trial = analysis.get_best_trial("mean_accuracy", "min")
+print(f"Best trial config: {best_trial.config}")
+print(f"Best trial mean_accuracy: {best_trial.last_result['mean_accuracy']}")

--- a/ray/adaptdl_ray/examples/hyperopt_example_baseline.py
+++ b/ray/adaptdl_ray/examples/hyperopt_example_baseline.py
@@ -1,0 +1,141 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+import torch.nn.functional as F
+
+import ray
+from ray import tune
+from ray.tune.integration.torch import DistributedTrainableCreator
+from ray.tune.suggest.hyperopt import HyperOptSearch
+
+from hyperopt import hp
+
+# Adapted from https://docs.ray.io/en/latest/tune/tutorials/tune-tutorial.html
+
+
+class ConvNet(nn.Module):
+    def __init__(self):
+        super(ConvNet, self).__init__()
+        # In this example, we don't change the model architecture
+        # due to simplicity.
+        self.conv1 = nn.Conv2d(1, 3, kernel_size=3)
+        self.fc = nn.Linear(192, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 3))
+        x = x.view(-1, 192)
+        x = self.fc(x)
+        return F.log_softmax(x, dim=1)
+
+
+# Change these values if you want the training to run quicker or slower.
+EPOCH_SIZE = 512
+TEST_SIZE = 256
+
+
+def train(model, optimizer, train_loader):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        # We set this just for the example to run quickly.
+        if batch_idx * len(data) > EPOCH_SIZE:
+            return
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+
+
+def test(model, data_loader):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for batch_idx, (data, target) in enumerate(data_loader):
+            # We set this just for the example to run quickly.
+            if batch_idx * len(data) > TEST_SIZE:
+                break
+            data, target = data.to(device), target.to(device)
+            outputs = model(data)
+            _, predicted = torch.max(outputs.data, 1)
+            total += target.size(0)
+            correct += (predicted == target).sum().item()
+    return correct / total
+
+
+def train_mnist(config: Dict, checkpoint_dir: Optional[str] = None):
+    # Data Setup
+    mnist_transforms = transforms.Compose(
+        [transforms.ToTensor(),
+         transforms.Normalize((0.1307, ), (0.3081, ))])
+
+    train_loader = DataLoader(datasets.MNIST("~/data", train=True,
+                              download=True, transform=mnist_transforms),
+                              batch_size=64,
+                              shuffle=True)
+
+    test_loader = DataLoader(
+        datasets.MNIST("~/data", train=False, transform=mnist_transforms),
+        batch_size=64,
+        shuffle=True)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model = ConvNet()
+    optimizer = optim.SGD(
+        model.parameters(), lr=config.get("lr", 0.01),
+        momentum=config.get("momentum", 0.79))
+
+    model.to(device)
+    model = DDP(model)
+
+    for epoch in range(config.get("epochs", 10)):
+        train(model, optimizer, train_loader)
+        acc = test(model, test_loader)
+        # Send the current training result back to Tune
+        tune.report(mean_accuracy=acc)
+
+
+ray.init(address="auto")
+
+trainable_cls = DistributedTrainableCreator(train_mnist, num_workers=4)
+
+space = {
+    "lr": hp.uniform("lr", 0.01, 0.1),
+    "momentum": hp.uniform("momentum", 0.1, 0.9),
+    "epochs": 100
+}
+
+hyperopt_search = HyperOptSearch(space, metric="mean_accuracy", mode="max")
+
+analysis = tune.run(
+    trainable_cls,
+    num_samples=16,  # total trials will be num_samples x points on the grid
+    search_alg=hyperopt_search)
+
+best_trial = analysis.get_best_trial("mean_accuracy", "min")
+print(f"Best trial config: {best_trial.config}")
+print(f"Best trial mean_accuracy: {best_trial.last_result['mean_accuracy']}")

--- a/ray/adaptdl_ray/examples/tune_proposal.py
+++ b/ray/adaptdl_ray/examples/tune_proposal.py
@@ -1,0 +1,96 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging, sys
+from typing import Callable, Dict, Generator, Optional, Type
+
+import torch
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+import torch.optim as optim
+from torch.utils.data import DataLoader
+
+import ray
+from ray import tune
+from ray.tune.integration.torch import DistributedTrainableCreator
+
+import adaptdl.torch as adl
+from adaptdl_ray.tune.adaptdl_trial_sched import AdaptDLScheduler
+
+
+class MyDataset:
+    def __init__(self, xs, ys):
+        self.xs = xs
+        self.ys = ys
+    
+    def __getitem__(self, i):
+        return self.xs[i], self.ys[i]
+    
+    def __len__(self):
+        return len(self.xs)
+    
+# N is batch size; D_in is input dimension;
+# H is hidden dimension; D_out is output dimension.
+N, D_in, _, D_out = 64, 5, 5, 5
+
+dataset = MyDataset(torch.randn(N, D_in), torch.randn(N, D_out))
+
+def _train_simple(config: Dict, checkpoint_dir: Optional[str] = None):
+    H = config.get("H", 16)
+    N = config.get("N", 16)
+
+    # Create random Tensors to hold inputs and outputs
+    dataloader = adl.AdaptiveDataLoader(dataset, batch_size=N)
+    dataloader.autoscale_batch_size(4096, local_bsz_bounds=(16, 1024))
+
+    loss_fn = nn.MSELoss()
+
+    # Use the nn package to define our model and loss function.
+    model = torch.nn.Sequential(
+        torch.nn.Linear(D_in, H),
+        torch.nn.ReLU(),
+        torch.nn.Linear(H, D_out),
+    )
+    optimizer = optim.SGD(model.parameters(), lr=0.1)
+
+    model = adl.AdaptiveDataParallel(model, optimizer)
+
+    loss = torch.Tensor([0.0])
+    for epoch in adl.remaining_epochs_until(config.get("epochs", 10)):
+        for (x, y) in dataloader:
+            optimizer.zero_grad()
+            output = model(x)
+            loss = loss_fn(output, y)
+            loss.backward()
+            optimizer.step()
+
+        tune.report(mean_loss=loss.item())
+
+
+ray.init(address="auto")
+
+trainable_cls = DistributedTrainableCreator(_train_simple)
+
+config_0 = {"epochs": 60}
+config_1 = {"epochs": 20, "H": tune.choice([8, 12]), "N": tune.grid_search(list(range(32, 64, 8)))}
+
+analysis = tune.run(
+    trainable_cls,
+    num_samples=2, # total trials will be num_samples x points on the grid
+    scheduler=AdaptDLScheduler(),
+    config=config_1,
+    metric="mean_loss",
+    mode="min")
+

--- a/ray/adaptdl_ray/tests/test_trial_sched.py
+++ b/ray/adaptdl_ray/tests/test_trial_sched.py
@@ -32,14 +32,14 @@ class IncrAllocator(AdaptDLAllocator):
     def __init__(self):
         super().__init__()
         # Reserve one CPU for the Trainable
-        self._avail_cpus = int(list(self._nodes.values())[0].resources["CPU"] - 1)
+        self._avail_cpus = int(list(self._node_infos.values())[0].resources["CPU"] - 1)
         self._cur_cpus = 1
     
     def default_allocation(self, num_devices=1):
         """ Use one device from the first node as default."""
-        return [f"{list(self._nodes)[0]}"] * num_devices
+        return [f"{list(self._node_infos)[0]}"] * num_devices
 
-    def allocate(self, jobs):
+    def allocate(self, jobs, nodes=None):
         if jobs[0]._num_replicas == self._cur_cpus:
             self._cur_cpus = min(self._cur_cpus + 1, self._avail_cpus)
         return {jobs[0].job_id: self.default_allocation(self._cur_cpus)}, 0
@@ -51,16 +51,16 @@ class DecrAllocator(AdaptDLAllocator):
     def __init__(self):
         super().__init__()
         # Reserve one CPU for the Trainable
-        self._avail_cpus = int(list(self._nodes.values())[0].resources["CPU"] - 1)
+        self._avail_cpus = int(list(self._node_infos.values())[0].resources["CPU"] - 1)
         self._cur_cpus = self._avail_cpus 
     
     def default_allocation(self, num_devices=None):
         """ Use one device from the first node as default."""
         if num_devices is None:
             num_devices = self._avail_cpus
-        return [f"{list(self._nodes)[0]}"] * num_devices
+        return [f"{list(self._node_infos)[0]}"] * num_devices
 
-    def allocate(self, jobs):
+    def allocate(self, jobs, nodes=None):
         if jobs[0]._num_replicas == self._cur_cpus:
             self._cur_cpus = max(self._cur_cpus - 1, 1)
         return {jobs[0].job_id: self.default_allocation(self._cur_cpus)}, 0
@@ -71,15 +71,15 @@ class PausingAllocator(AdaptDLAllocator):
     def __init__(self):
         super().__init__()
         # Reserve one CPU for the Trainable
-        self._avail_cpus = int(list(self._nodes.values())[0].resources["CPU"] - 1)
+        self._avail_cpus = int(list(self._node_infos.values())[0].resources["CPU"] - 1)
         self._cur_cpus = 1
         self._toggle = True
 
     def default_allocation(self, num_devices=1):
         """ Use one device from the first node as default."""
-        return [f"{list(self._nodes)[0]}"] * num_devices
+        return [f"{list(self._node_infos)[0]}"] * num_devices
 
-    def allocate(self, jobs):
+    def allocate(self, jobs, nodes=None):
         if self._toggle:
             self._toggle = False
             return {jobs[0].job_id: self.default_allocation(self._cur_cpus)}, 0

--- a/ray/adaptdl_ray/tests/test_trial_sched.py
+++ b/ray/adaptdl_ray/tests/test_trial_sched.py
@@ -1,0 +1,105 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+import sys
+
+from typing import Callable, Dict, Generator, Optional, Type
+
+import ray
+from ray import tune
+from ray.tune.integration.torch import DistributedTrainableCreator
+from adaptdl_ray.tune.adaptdl_trial_sched import AdaptDLScheduler
+from adaptdl_ray.adaptdl import AdaptDLAllocator
+from adaptdl_ray.tune.adaptdl_trainable import _train_simple
+
+
+class IncrAllocator(AdaptDLAllocator):
+    """Increment allocation by 1 starting with 1"""
+    __test__ = False
+    def __init__(self):
+        super().__init__()
+        self._avail_cpus = int(list(self._nodes.values())[0].resources["CPU"])
+        self._cur_cpus = 1
+    
+    def default_allocation(self, num_devices=1):
+        """ Use one device from the first node as default."""
+        return [f"{list(self._nodes)[0]}"] * num_devices
+
+    def allocate(self, jobs):
+        if jobs[0]._num_replicas == self._cur_cpus:
+            self._cur_cpus = min(self._cur_cpus + 1, self._avail_cpus)
+        return {jobs[0].job_id: self.default_allocation(self._cur_cpus)}, 0
+
+
+class DecrAllocator(AdaptDLAllocator):
+    """Decrement allocation by 1 starting with max"""
+    __test__ = False
+    def __init__(self):
+        super().__init__()
+        self._avail_cpus = int(list(self._nodes.values())[0].resources["CPU"])
+        self._cur_cpus = self._avail_cpus 
+    
+    def default_allocation(self, num_devices=None):
+        """ Use one device from the first node as default."""
+        if num_devices is None:
+            num_devices = self._avail_cpus
+        return [f"{list(self._nodes)[0]}"] * num_devices
+
+    def allocate(self, jobs):
+        if jobs[0]._num_replicas == self._cur_cpus:
+            self._cur_cpus = max(self._cur_cpus - 1, 1)
+        return {jobs[0].job_id: self.default_allocation(self._cur_cpus)}, 0
+
+EPOCHS = 60
+NUM_CPUS_CLUSTER = 4
+
+class MyTest(unittest.TestCase):
+    def setUp(self):
+        ray.init(num_cpus=NUM_CPUS_CLUSTER, include_dashboard=False)
+
+    def tearDown(self):
+        ray.shutdown()
+
+    def testSchedulerDecr(self):
+        trainable_cls = DistributedTrainableCreator(_train_simple)
+        analysis = tune.run(
+            trainable_cls,
+            name="Decr",
+            num_samples=1,
+            scheduler=AdaptDLScheduler(DecrAllocator()),
+            config={"epochs": EPOCHS},
+            metric="mean_loss",
+            mode="min")
+        assert len(analysis.results_df) == 1
+        assert analysis._checkpoints[0]["last_result"]["training_iteration"] >= EPOCHS
+    
+    def testSchedulerIncr(self):
+        trainable_cls = DistributedTrainableCreator(_train_simple)
+        analysis = tune.run(
+            trainable_cls,
+            name="Incr",
+            num_samples=1,
+            scheduler=AdaptDLScheduler(IncrAllocator()),
+            config={"epochs": EPOCHS},
+            metric="mean_loss",
+            mode="min")
+        assert len(analysis.results_df) == 1
+        assert analysis._checkpoints[0]["last_result"]["training_iteration"] >= EPOCHS
+
+if __name__ == "__main__":
+    import pytest, sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/ray/adaptdl_ray/tests/test_trial_sched.py
+++ b/ray/adaptdl_ray/tests/test_trial_sched.py
@@ -14,13 +14,11 @@
 
 
 import unittest
-import sys
-
-from typing import Callable, Dict, Generator, Optional, Type
 
 import ray
 from ray import tune
 from ray.tune.integration.torch import DistributedTrainableCreator
+
 from adaptdl_ray.tune.adaptdl_trial_sched import AdaptDLScheduler
 from adaptdl_ray.adaptdl import AdaptDLAllocator
 from adaptdl_ray.tune.adaptdl_trainable import _train_simple
@@ -29,12 +27,14 @@ from adaptdl_ray.tune.adaptdl_trainable import _train_simple
 class IncrAllocator(AdaptDLAllocator):
     """Increment allocation by 1 starting with 1"""
     __test__ = False
+
     def __init__(self):
         super().__init__()
         # Reserve one CPU for the Trainable
-        self._avail_cpus = int(list(self._node_infos.values())[0].resources["CPU"] - 1)
+        self._avail_cpus = int(list(self._node_infos.values())[0].
+                               resources["CPU"] - 1)
         self._cur_cpus = 1
-    
+
     def default_allocation(self, num_devices=1):
         """ Use one device from the first node as default."""
         return [f"{list(self._node_infos)[0]}"] * num_devices
@@ -48,12 +48,14 @@ class IncrAllocator(AdaptDLAllocator):
 class DecrAllocator(AdaptDLAllocator):
     """Decrement allocation by 1 starting with max"""
     __test__ = False
+
     def __init__(self):
         super().__init__()
         # Reserve one CPU for the Trainable
-        self._avail_cpus = int(list(self._node_infos.values())[0].resources["CPU"] - 1)
-        self._cur_cpus = self._avail_cpus 
-    
+        self._avail_cpus = int(list(self._node_infos.values())[0].
+                               resources["CPU"] - 1)
+        self._cur_cpus = self._avail_cpus
+
     def default_allocation(self, num_devices=None):
         """ Use one device from the first node as default."""
         if num_devices is None:
@@ -68,10 +70,12 @@ class DecrAllocator(AdaptDLAllocator):
 
 class PausingAllocator(AdaptDLAllocator):
     __test__ = False
+
     def __init__(self):
         super().__init__()
         # Reserve one CPU for the Trainable
-        self._avail_cpus = int(list(self._node_infos.values())[0].resources["CPU"] - 1)
+        self._avail_cpus = int(list(self._node_infos.values())[0].
+                               resources["CPU"] - 1)
         self._cur_cpus = 1
         self._toggle = True
 
@@ -91,6 +95,7 @@ class PausingAllocator(AdaptDLAllocator):
 EPOCHS = 60
 NUM_CPUS_CLUSTER = 5
 
+
 class MyTest(unittest.TestCase):
     def setUp(self):
         ray.init(num_cpus=NUM_CPUS_CLUSTER, include_dashboard=False)
@@ -109,8 +114,7 @@ class MyTest(unittest.TestCase):
             metric="mean_loss",
             mode="min")
         assert len(analysis.results_df) == 1
-        assert analysis._checkpoints[0]["last_result"]["training_iteration"] >= EPOCHS
-    
+
     def testSchedulerIncr(self):
         trainable_cls = DistributedTrainableCreator(_train_simple)
         analysis = tune.run(
@@ -122,8 +126,7 @@ class MyTest(unittest.TestCase):
             metric="mean_loss",
             mode="min")
         assert len(analysis.results_df) == 1
-        assert analysis._checkpoints[0]["last_result"]["training_iteration"] >= EPOCHS
-    
+
     def testSchedulerPausing(self):
         trainable_cls = DistributedTrainableCreator(_train_simple)
         analysis = tune.run(
@@ -138,6 +141,7 @@ class MyTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest, sys
+    import pytest
+    import sys
 
     sys.exit(pytest.main(["-v", __file__]))

--- a/ray/adaptdl_ray/tune/__init__.py
+++ b/ray/adaptdl_ray/tune/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ray/adaptdl_ray/tune/adaptdl_patch.py
+++ b/ray/adaptdl_ray/tune/adaptdl_patch.py
@@ -16,21 +16,23 @@
 import types
 import shutil
 
-import ray
 from ray.tune.function_runner import wrap_function
 from ray.tune.trainable import TrainableUtil
 
 from adaptdl.torch import init_process_group
-from adaptdl.checkpoint import save_all_states 
+from adaptdl.checkpoint import save_all_states
 from adaptdl.torch._metrics import _get_sched_hints
 
 
 # Wrap the free functions of AdaptDL with FunctionRunner methods
 def save_all_states_remote(self, trial_state):
-    """ Save all of AdaptDL's job state and return it as an in-memory object."""
+    """ Save all of AdaptDL's job state and return it as an in-memory
+    object."""
     checkpoint = save_all_states()
     parent_dir = TrainableUtil.find_checkpoint_dir(checkpoint)
-    checkpoint_path = TrainableUtil.process_checkpoint(checkpoint, parent_dir, trial_state)
+    checkpoint_path = TrainableUtil.process_checkpoint(checkpoint,
+                                                       parent_dir,
+                                                       trial_state)
     checkpoint_obj = TrainableUtil.checkpoint_to_object(checkpoint_path)
     # Done with the directory, remove
     shutil.rmtree(checkpoint_path)
@@ -45,8 +47,10 @@ def get_sched_hints_remote(self):
 def wrap_function_patched(function):
     """ Monkey-patch FunctionRunner remote trainable"""
     func_trainable = wrap_function(function)
-    func_trainable.save_all_states = types.MethodType(save_all_states_remote, func_trainable)
-    func_trainable.get_sched_hints = types.MethodType(get_sched_hints_remote, func_trainable)
+    func_trainable.save_all_states = types.MethodType(save_all_states_remote,
+                                                      func_trainable)
+    func_trainable.get_sched_hints = types.MethodType(get_sched_hints_remote,
+                                                      func_trainable)
     return func_trainable
 
 

--- a/ray/adaptdl_ray/tune/adaptdl_patch.py
+++ b/ray/adaptdl_ray/tune/adaptdl_patch.py
@@ -56,6 +56,6 @@ def wrap_function_patched(function):
 
 def setup_process_group(*args, **kwargs):
     init_process_group(backend=kwargs["backend"],
-                       replica_rank=kwargs["world_rank"],
-                       num_replicas=kwargs["world_size"],
-                       address=kwargs["url"])
+                       init_method=kwargs["url"],
+                       world_size=kwargs["world_size"],
+                       rank=kwargs["world_rank"])

--- a/ray/adaptdl_ray/tune/adaptdl_patch.py
+++ b/ray/adaptdl_ray/tune/adaptdl_patch.py
@@ -1,0 +1,57 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import types
+import shutil
+
+import ray
+from ray.tune.function_runner import wrap_function
+from ray.tune.trainable import TrainableUtil
+
+from adaptdl.torch import init_process_group
+from adaptdl.checkpoint import save_all_states 
+from adaptdl.torch._metrics import _get_sched_hints
+
+
+# Wrap the free functions of AdaptDL with FunctionRunner methods
+def save_all_states_remote(self, trial_state):
+    """ Save all of AdaptDL's job state and return it as an in-memory object."""
+    checkpoint = save_all_states()
+    parent_dir = TrainableUtil.find_checkpoint_dir(checkpoint)
+    checkpoint_path = TrainableUtil.process_checkpoint(checkpoint, parent_dir, trial_state)
+    checkpoint_obj = TrainableUtil.checkpoint_to_object(checkpoint_path)
+    # Done with the directory, remove
+    shutil.rmtree(checkpoint_path)
+    return checkpoint_obj
+
+
+def get_sched_hints_remote(self):
+    """ Return hints for AdaptDL Scheduler."""
+    return _get_sched_hints()
+
+
+def wrap_function_patched(function):
+    """ Monkey-patch FunctionRunner remote trainable"""
+    func_trainable = wrap_function(function)
+    func_trainable.save_all_states = types.MethodType(save_all_states_remote, func_trainable)
+    func_trainable.get_sched_hints = types.MethodType(get_sched_hints_remote, func_trainable)
+    return func_trainable
+
+
+def setup_process_group(*args, **kwargs):
+    init_process_group(backend=kwargs["backend"],
+                       replica_rank=kwargs["world_rank"],
+                       num_replicas=kwargs["world_size"],
+                       address=kwargs["url"])

--- a/ray/adaptdl_ray/tune/adaptdl_trainable.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trainable.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Callable, Dict, Generator, Optional, Type
+from unittest.mock import patch
+from datetime import timedelta
+
+import ray
+from ray.tune.resources import Resources
+from ray.tune.registry import get_trainable_cls, register_trainable
+from ray.tune.integration.torch import _TorchTrainable
+from ray.util.sgd.torch.constants import NCCL_TIMEOUT_S
+
+import adaptdl_ray.tune.adaptdl_patch as P 
+
+
+def AdaptDLTrainableCreator(func: Callable,
+                            num_workers: int = 1,
+                            group: int = 0,
+                            num_cpus_per_worker: int = 1,
+                            num_gpus_per_worker: int = 0,
+                            num_workers_per_host: Optional[int] = None,
+                            backend: str = "gloo",
+                            timeout_s: int = NCCL_TIMEOUT_S,
+                            use_gpu=None):
+    class AdaptDLTrainable(_TorchTrainable):
+        """ Similar to DistributedTrainable but for AdaptDLTrials."""
+        def setup(self, config: Dict):
+            """ Delay-patch methods when the Trainable actors are first initialized"""
+            with patch(target="ray.tune.integration.torch.setup_process_group", new=P.setup_process_group), \
+                patch(target='ray.tune.integration.torch.wrap_function', new=P.wrap_function_patched):
+                    _TorchTrainable.setup(self, config)
+
+        # Override the default resources and use custom PG factory
+        @classmethod
+        def default_resource_request(cls, config: Dict) -> Resources:
+            return None
+
+        def get_sched_hints(self):
+            return ray.get(self.workers[0].get_sched_hints.remote())
+
+        def save_all_states(self, trial_state):
+            return ray.get(self.workers[0].save_all_states.remote(trial_state))
+
+        @classmethod
+        def default_process_group_parameters(self) -> Dict:
+            return dict(timeout=timedelta(timeout_s), backend=backend)
+
+    AdaptDLTrainable._function = func
+    AdaptDLTrainable._num_workers = num_workers
+
+    # Trainables are named after number of replicas they spawn. This is
+    # essential to associate the right Trainable with the right Trial and PG.
+    AdaptDLTrainable.__name__ = AdaptDLTrainable.__name__.split("_")[0] \
+                                + f"_{num_workers}" + f"_{group}"
+    
+    register_trainable(AdaptDLTrainable.__name__, AdaptDLTrainable)
+    return AdaptDLTrainable

--- a/ray/adaptdl_ray/tune/adaptdl_trainable_test.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trainable_test.py
@@ -1,0 +1,56 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import torch.distributed as dist
+import ray
+
+from .adaptdl_trainable import AdaptDLTrainableCreator, _train_simple
+
+
+@pytest.fixture
+def ray_start_2_cpus():
+    address_info = ray.init(num_cpus=2)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    # Ensure that tests don't ALL fail
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def test_single_step(ray_start_2_cpus):  # noqa: F811
+    trainable_cls = AdaptDLTrainableCreator(_train_simple, num_workers=2)
+    trainer = trainable_cls()
+    trainer.train()
+    trainer.stop()
+
+
+def test_step_after_completion(ray_start_2_cpus):  # noqa: F811
+    trainable_cls = AdaptDLTrainableCreator(_train_simple, num_workers=2)
+    trainer = trainable_cls(config={"epochs": 1})
+    with pytest.raises(RuntimeError):
+        for i in range(10):
+            trainer.train()
+
+
+def test_save_checkpoint_restore(ray_start_2_cpus):  # noqa: F811
+    trainable_cls = AdaptDLTrainableCreator(_train_simple, num_workers=2)
+    trainer = trainable_cls(config={"epochs": 1})
+    trainer.train()
+    checkpoint_dir = trainer.save()
+    trainer.restore(checkpoint_dir)
+    trainer.train()
+    trainer.stop()

--- a/ray/adaptdl_ray/tune/adaptdl_trial.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial.py
@@ -42,7 +42,10 @@ class AdaptDLTrial(AdaptDLJobMixin, Trial):
     def __init__(self, *args, **kwargs):
         super().__init__(job_id=kwargs["trial_id"], *args, **kwargs)
         self.rescale_count = 0
-        self.reallocation_count = 0
+
+    @property
+    def _num_replicas(self):
+        return self.get_trainable_cls()._num_workers
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/ray/adaptdl_ray/tune/adaptdl_trial.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial.py
@@ -1,0 +1,114 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, List, Optional, Union
+from datetime import datetime, timedelta
+from collections import Counter
+import logging
+
+import ray
+from ray.tune.trial import Trial 
+from ray.tune.function_runner import FuncCheckpointUtil
+from ray.tune.trainable import TrainableUtil
+
+from adaptdl_ray.adaptdl import AdaptDLJobMixin
+from adaptdl_ray.tune.adaptdl_trainable import AdaptDLTrainableCreator
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class AdaptDLTrial(AdaptDLJobMixin, Trial):
+    """ Tune Trial that brings in AdaptDL functionality. """
+    def __init__(self, *args, **kwargs):
+        super().__init__(job_id=kwargs["trial_id"], *args, **kwargs)
+        self.rescale_count = 0
+
+    def _requeue(self, old_trial: Trial, trial_runner: "trial_runner.TrialRunner"):
+        # Remove the old trial from trial_runner
+        trial_runner.trial_executor.stop_trial(old_trial, destroy_pg_if_cannot_replace=False)
+        trial_runner._trials.pop(trial_runner._trials.index(old_trial))
+        # Important: Add the new trial to the runner
+        trial_runner._trials.append(self)
+        trial_runner._live_trials.add(self)
+
+    def _fetch_metrics(self):
+        return ray.get(self.runner.get_sched_hints.remote()) if self.runner else None
+
+    def _allocation_in_use(self):
+        return self._trial_in_use_fn(self)
+
+    @classmethod
+    def _clone_from(cls, trial: Trial, allocation, restore_path=None) -> "AdaptDLTrial":
+        trainable_cls = trial.get_trainable_cls()
+        pgf = cls.allocation_to_pgf(allocation)
+        num_workers = cls._pgf_to_num_replicas(pgf)
+        assert num_workers > 0
+        rescale_count = trial.rescale_count + 1 if isinstance(trial, AdaptDLTrial) else 1
+
+        adaptdl_trainable_cls = AdaptDLTrainableCreator(trainable_cls._function, 
+                                                        num_workers, 
+                                                        group=rescale_count)
+        return cls(trainable_name=adaptdl_trainable_cls.__name__,
+                   config=trial.config,
+                   experiment_tag=trial.experiment_tag,
+                   trial_id=trial.trial_id,
+                   restore_path=restore_path,
+                   local_dir="/tmp",  # TODO: Decide a proper way
+                   placement_group_factory=pgf)
+
+    @classmethod
+    def create_from(cls, trial: Trial, trial_runner: "trial_runner.TrialRunner", 
+                     new_allocation: List[str], copy_state=False) -> "AdaptDLTrial":
+        """ Create a new AdaptDLTrial from a Trial or AdaptDLTrial with new
+        allocations. This also replaces the existing Trial."""
+
+        checkpoint_path = None
+        logger.debug(f"Creating {trial} with {len(new_allocation)} replicas")
+        if copy_state:
+            # Fetch the state from the other trial
+            assert trial.runner is not None
+            checkpoint_obj = ray.get(trial.runner.save_all_states.remote(
+                                     trial.runner.get_state.remote()))
+            # Dump it to disk
+            temp_checkpoint_dir = (FuncCheckpointUtil.mk_temp_checkpoint_dir(trial.logdir))
+            checkpoint_path = TrainableUtil.create_from_pickle(checkpoint_obj, temp_checkpoint_dir)
+            
+        # Spawn a new trial
+        new_trial = cls._clone_from(trial, new_allocation, restore_path=checkpoint_path)
+        # Keep it for later use by the trials
+        new_trial._trial_in_use_fn = trial_runner.trial_executor._pg_manager.trial_in_use
+        new_trial.rescale_count += 1
+        # Replace with old trial
+        new_trial._requeue(trial, trial_runner)
+        assert new_trial.restore_path == checkpoint_path
+        assert new_trial.status == Trial.PENDING
+        return new_trial
+
+    def pause(self, trial_runner):
+        """ Pause a AdaptDLTrial with a checkpoint."""
+        assert self.runner is not None
+        checkpoint_obj = ray.get(self.runner.save_all_states.remote(
+                                 self.runner.get_state.remote()))
+
+        # Serialize it to disk
+        temp_checkpoint_dir = (FuncCheckpointUtil.mk_temp_checkpoint_dir(self.logdir))
+        checkpoint_path = TrainableUtil.create_from_pickle(checkpoint_obj, temp_checkpoint_dir)
+
+        # Trial will be restored from the checkpoint_path when it's resumed
+        self.restore_path = checkpoint_path
+        # Clear the allocation
+        logger.debug(f"PAUSING {self} w/ checkpoint at {checkpoint_path}")

--- a/ray/adaptdl_ray/tune/adaptdl_trial.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial.py
@@ -31,7 +31,7 @@ from ray.tune.trial import Location
 
 from adaptdl_ray.adaptdl import AdaptDLJobMixin
 from adaptdl_ray.tune.adaptdl_trainable import AdaptDLTrainableCreator
-
+from adaptdl_ray.adaptdl.utils import pgf_to_num_replicas, allocation_to_pgf
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -86,8 +86,8 @@ class AdaptDLTrial(AdaptDLJobMixin, Trial):
     @classmethod
     def _clone_from(cls, trial: Trial, allocation, restore_path=None) -> "AdaptDLTrial":
         trainable_cls = trial.get_trainable_cls()
-        pgf = cls.allocation_to_pgf(allocation)
-        num_workers = cls._pgf_to_num_replicas(pgf)
+        pgf = allocation_to_pgf(allocation)
+        num_workers = pgf_to_num_replicas(pgf)
         assert num_workers > 0
         rescale_count = trial.rescale_count + 1 if isinstance(trial, AdaptDLTrial) else 1
 

--- a/ray/adaptdl_ray/tune/adaptdl_trial.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial.py
@@ -82,13 +82,11 @@ class AdaptDLTrial(AdaptDLJobMixin, Trial):
 
     def _fetch_metrics(self):
         if self.runner is not None:
-            self._cached_metrics = \
-                    ray.get(self.runner.get_sched_hints.remote())
-            return self._cached_metrics
-        elif self._cached_metrics is not None:
-            return self._cached_metrics
-        else:
-            return None
+            metrics = ray.get(self.runner.get_sched_hints.remote())
+            if metrics is not None:
+                # Update cache
+                self._cached_metrics = metrics
+        return self._cached_metrics
 
     def _allocation_in_use(self):
         return self._trial_in_use(self)

--- a/ray/adaptdl_ray/tune/adaptdl_trial.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial.py
@@ -113,7 +113,6 @@ class AdaptDLTrial(AdaptDLJobMixin, Trial):
         if copy_state:
             if trial.runner is not None:
                 # Fetch the state from the other trial
-                assert trial.runner is not None
                 checkpoint_obj = ray.get(trial.runner.save_all_states.remote(
                                          trial.runner.get_state.remote()))
                 # Dump it to disk

--- a/ray/adaptdl_ray/tune/adaptdl_trial_sched.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial_sched.py
@@ -1,0 +1,100 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, List, Optional, Union
+
+import ray
+from ray.tune.schedulers import TrialScheduler
+from ray.tune.trial import Trial
+
+from adaptdl_ray.tune.adaptdl_trial import AdaptDLTrial
+from adaptdl_ray.adaptdl import AdaptDLAllocator
+
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class AdaptDLScheduler(TrialScheduler):
+    """AdaptDL TrialScheduler."""
+
+    def __init__(self):
+        self._counter = 0
+        self._allocator = AdaptDLAllocator()
+
+    def on_trial_add(self, trial_runner: "trial_runner.TrialRunner",
+                     trial: Trial):
+        """Called after SearchAlgorithm.next_trial"""
+        trial = AdaptDLTrial.create_from(trial, trial_runner, 
+                                         self._allocator.default_allocation())
+
+    def on_trial_error(self, trial_runner: "trial_runner.TrialRunner",
+                       trial: Trial):
+        pass
+
+    def on_trial_result(self, trial_runner: "trial_runner.TrialRunner",
+                        trial: Trial, result: Dict) -> str:
+
+        trials = [trial for trial in trial_runner.get_trials() \
+                    if trial.status in (Trial.RUNNING, Trial.PENDING)]
+        self._counter += 1
+        # Some arbitrary condition
+        if self._counter % 20 == 0:
+            # This may trigger excessive Experiment checkpointing
+            # we set it here at high value to avoid that
+            trial_runner._checkpoint_manager._checkpoint_period = 100
+            allocs, desired = self._allocator.allocate(trials)
+        else:
+            allocs = {trial.trial_id: trial.allocation for trial in trials}
+
+        if allocs.get(trial.trial_id, []) == [] and trial.status == Trial.RUNNING:
+            # Pause only if the trial is running
+            trial.pause(trial_runner)
+            # Pause this trial
+            return TrialScheduler.PAUSE
+        elif allocs.get(trial.trial_id, []) != trial.allocation:
+            trial = AdaptDLTrial.create_from(trial, 
+                                             trial_runner, 
+                                             allocs.get(trial.trial_id, []),
+                                             copy_state=True)
+            # Stop the old trial that's being replaced
+            return TrialScheduler.STOP
+        return TrialScheduler.CONTINUE
+
+    def on_trial_complete(self, trial_runner: "trial_runner.TrialRunner",
+                          trial: Trial, result: Dict):
+        pass
+
+    def on_trial_remove(self, trial_runner: "trial_runner.TrialRunner",
+                        trial: Trial):
+        pass
+
+    def choose_trial_to_run(
+            self, trial_runner: "trial_runner.TrialRunner") -> Optional[Trial]:
+        for trial in trial_runner.get_trials():
+            if (trial.status == Trial.PENDING
+                    and trial_runner.has_resources_for_trial(trial)):
+                return trial
+        for trial in trial_runner.get_trials():
+            if (trial.status == Trial.PAUSED
+                    and trial_runner.has_resources_for_trial(trial)):
+                # Note: this puts the trial back to RUNNING. Need the new trial
+                # to have the old chekcpoint
+                return trial
+        return None
+
+    def debug_string(self) -> str:
+        return "Using AdaptDL scheduling algorithm."
+

--- a/ray/adaptdl_ray/tune/adaptdl_trial_sched.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial_sched.py
@@ -32,7 +32,7 @@ logger.setLevel(logging.DEBUG)
 class AdaptDLScheduler(TrialScheduler):
     """AdaptDL TrialScheduler."""
 
-    _ALLOCATOR_INVOKE_FREQ = 40
+    _ALLOCATOR_INVOKE_FREQ = 50
 
     @staticmethod
     def _try_realloc(iteration):
@@ -70,6 +70,7 @@ class AdaptDLScheduler(TrialScheduler):
         if allocs.get(trial.trial_id) == [] and trial.status == Trial.RUNNING:
             # Pause only if the trial is running
             trial.pause(trial_runner)
+            trial_runner.trial_executor._pg_manager.reconcile_placement_groups(trials)
             return TrialScheduler.PAUSE
         elif allocs.get(trial.trial_id) != trial.allocation:
             trial = AdaptDLTrial.create_from(trial, 
@@ -82,7 +83,7 @@ class AdaptDLScheduler(TrialScheduler):
 
     def on_trial_complete(self, trial_runner: "trial_runner.TrialRunner",
                           trial: Trial, result: Dict):
-        pass
+        trial_runner.trial_executor._pg_manager.reconcile_placement_groups([trial])
 
     def on_trial_remove(self, trial_runner: "trial_runner.TrialRunner",
                         trial: Trial):

--- a/ray/adaptdl_ray/tune/adaptdl_trial_test.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial_test.py
@@ -1,0 +1,78 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import unittest
+
+import ray
+
+from ray import tune
+from ray.tune.ray_trial_executor import RayTrialExecutor
+from ray.tune.trial import Trial
+from ray.tune.suggest import BasicVariantGenerator
+from .adaptdl_trial import AdaptDLTrial
+from .adaptdl_trainable import AdaptDLTrainableCreator, _train_simple
+
+
+class TrialRunnerTest(unittest.TestCase):
+    def setUp(self):
+        # Wait up to five seconds for placement groups when starting a trial
+        os.environ["TUNE_PLACEMENT_GROUP_WAIT_S"] = "5"
+        # Block for results even when placement groups are pending
+        os.environ["TUNE_TRIAL_STARTUP_GRACE_PERIOD"] = "0"
+        os.environ["TUNE_TRIAL_RESULT_WAIT_TIME_S"] = "99999"
+
+    def tearDown(self):
+        ray.shutdown()
+
+    def testTrialStatus(self):
+        ray.init(num_cpus=2)
+        trainable_cls = AdaptDLTrainableCreator(_train_simple, num_workers=2)
+        trial = AdaptDLTrial(trainable_cls.__name__, trial_id="0")
+        trial_executor = RayTrialExecutor()
+        assert trial.status == Trial.PENDING
+        trial_executor.start_trial(trial)
+        assert trial.status == Trial.RUNNING
+        trial_executor.stop_trial(trial)
+        assert trial.status == Trial.TERMINATED
+        trial_executor.stop_trial(trial, error=True)
+        assert trial.status == Trial.ERROR
+
+    def testExperimentTagTruncation(self):
+        ray.init(num_cpus=2)
+        trainable_cls = AdaptDLTrainableCreator(_train_simple, num_workers=1)
+        trial_executor = RayTrialExecutor()
+        experiments = {
+            "foo": {
+                "run": trainable_cls.__name__,
+                "config": {
+                    "a" * 50: tune.sample_from(lambda spec: 5.0 / 7),
+                    "b" * 50: tune.sample_from(lambda spec: "long" * 40)
+                },
+            }
+        }
+
+        for name, spec in experiments.items():
+            trial_generator = BasicVariantGenerator()
+            trial_generator.add_configurations({name: spec})
+            while not trial_generator.is_finished():
+                trial = trial_generator.next_trial()
+                if not trial:
+                    break
+                trial_executor.start_trial(trial)
+                assert trial.status == Trial.RUNNING
+                assert len(os.path.basename(trial.logdir)) <= 200
+                trial_executor.stop_trial(trial)
+                assert trial.status == Trial.TERMINATED

--- a/ray/requirements.txt
+++ b/ray/requirements.txt
@@ -1,0 +1,2 @@
+adaptdl>=0.0.0
+adaptdl-sched>=0.0.0

--- a/ray/requirements.txt
+++ b/ray/requirements.txt
@@ -1,2 +1,3 @@
+ray>=1.8.0
 adaptdl>=0.0.0
 adaptdl-sched>=0.0.0

--- a/ray/setup.py
+++ b/ray/setup.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import setuptools
+
+
+def read_requirements(file_path):
+    requirements = []
+    with open(file_path) as f:
+        for line in f:
+            if "#" in line:
+                line = line[:line.index("#")]
+            line = line.strip()
+            if line and not line.startswith("-"):
+                requirements.append(line)
+    return requirements
+
+
+if __name__ == "__main__":
+    setuptools.setup(
+        name="adaptdl-ray",
+        version=os.getenv("ADAPTDL_RAY_VERSION", "0.0.0"),
+        author="Petuum Inc. & The AdaptDL Authors",
+        author_email="aurick.qiao@petuum.com",
+        description="Dynamic-resource trainer and scheduler for deep learning",
+        url="https://github.com/petuum/adaptdl",
+        classifiers=[
+            "Programming Language :: Python :: 3",
+            "License :: Other/Proprietary License",
+            "Operating System :: POSIX :: Linux",
+        ],
+        packages=setuptools.find_packages(include=["adaptdl_ray",
+                                                   "adaptdl_ray.*"]),
+        python_requires='>=3.6',
+        install_requires=read_requirements("requirements.txt"),
+    )


### PR DESCRIPTION
This PR implements Adaptive Tune Trial Scheduler which effectively ports AdaptDL over Ray. The AdaptDL Trial Scheduler can be used like any other Tune scheduler with any Tune `DistributedTrainable`.  The full proposal can be found at https://github.com/ray-project/ray/issues/17054 

The implementation consists of below components:

1. `AdaptDLScheduler`
This is the user-exposed class that implements the elastic scheduling functionality from AdaptDL for Tune trials. It invokes the AdaptDL allocator at a fixed frequency counted in the number of epochs observed by the scheduler (which can be controlled by the parameter `allocator_invoke_freq`). The job of the scheduler is to find the optimal resources for each trial of the experiment with the help of the `AdaptDLAllocator` and then applying those changes to the running trials seamlessly. As a result, individual trials can expand or contract throughout their lifetimes, by changing the number of replicas they run with, based on their performance characteristics and available Ray cluster resources. We maintain the model and dataloader state during the rescaling events with the help of checkpoints managed by the `AdaptDLTrial`s.

2. `AdaptDLJobMixin`
This is an interface between Tune trials and AdaptDL jobs (as seen by the `AdaptDLAllocator`). The mixin presents a clean interface to `AdaptDLAllocator` which is responsible for fairly distributing available cluster resources between all the trials. It primarily holds the current allocation and the `JobInfo` structure for the `AdaptDLTrial`. This is used by both the `AdaptDLAllocator` and `AdaptDLScheduler` to make decisions about trials and execute them.

3. `AdaptDLAllocator`
Uses the interface implemented by the mixin to generate an allocation plan for the jobs/trials. This is a wrapper over the job allocator from AdaptDL.

4. `AdaptDLTrial(AdaptDLJobMixin, Tune.Trial)`
This combines the interface mixin with Tune trials. It mainly implements two methods that are used by the scheduler, namely `create_from` which creates or rescales the `AdaptDLTrial` and `pause` which pauses the `AdaptDLTrial` and releases all resources allocated to it. This presents a simple interface to the `AdaptDLScheduler` to control `AdaptDLTrial`s. 

5. `AdaptDLTrainableCreator`
This module implements the function that creates AdaptDL `DistributedTrainable`  from the user-provided training function (see examples). Trainables are classes which comply with the Tune specification of a `Trainable` and methods of which are invoked by Tune to control the execution of trials created from them. In our case, because the trainables are distributed, they end up spawning more replica actors which are responsible for running the training loop. It is the responsibility of the `AdaptDLAllocator` to provide resources for the entire ensemble. 


Depends on https://github.com/ray-project/ray/pull/19349