### PR TITLE
Use empty string for all-inclusive pod-label-selector

### DIFF
--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -144,13 +144,15 @@ class AdaptDLAllocator(object):
                 await patch_job_status(self._objs_api, namespace, name, patch)
 
     async def _find_nodes(self, pod_label_selector=""):
+        # NOTE: Default empty string "" label_selector qualifies all pods
         node_infos = {}
         node_list = await self._core_api.list_node()
-        # Find all non-AdaptDL pods which are taking up resources and subtract
-        # those resources from the available pool. Apparently there's not a
-        # more efficient way to get currently available resources in k8s?. We
-        # also check if we have reached the pod limit on the node. This number
-        # denotes (allocatable pods - Non-terminated pods) on that node.
+        # Find all pods qualified by the pod_label_selector which are taking up
+        # resources and subtract those resources from the available pool.
+        # Apparently there's not a more efficient way to get currently
+        # available resources in k8s?. We also check if we have reached the pod
+        # limit on the node. This number denotes (allocatable pods -
+        # Non-terminated pods) on that node.
         pod_list = await self._core_api.list_pod_for_all_namespaces(
                                 label_selector=pod_label_selector)
         for node in node_list.items:

--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -143,7 +143,7 @@ class AdaptDLAllocator(object):
                 LOG.info("Patch AdaptDLJob %s/%s: %s", namespace, name, patch)
                 await patch_job_status(self._objs_api, namespace, name, patch)
 
-    async def _find_nodes(self, pod_label_selector=None):
+    async def _find_nodes(self, pod_label_selector=""):
         node_infos = {}
         node_list = await self._core_api.list_node()
         # Find all non-AdaptDL pods which are taking up resources and subtract


### PR DESCRIPTION
Two successive non-preemptible AdaptDL jobs received same allocation by the single job allocation optimization introduced by #66

```
INFO:__main__:Patch AdaptDLJob  namespace/a-b-c-dzjr4: {'status': {'allocation': ['X.Y.0.232']}}
INFO:__main__:Patch AdaptDLJob  namespace/a-b-c-qczpw: {'status': {'allocation': ['X.Y.0.232']}}
```
The jobs being non-preemptible, this later crashes in the Pollux optimizer (because two jobs have same allocation) when a full allocation cycle starts.
```
    await self._optimize_all()
  File "/usr/local/lib/python3.8/site-packages/adaptdl_sched/allocator.py", line 126, in _optimize_all
    allocations = self._allocate(jobs, nodes, prev_allocations,
  File "/usr/local/lib/python3.8/site-packages/adaptdl_sched/allocator.py", line 259, in _allocate
    allocations, desired_nodes = self._policy.optimize(
  File "/usr/local/lib/python3.8/site-packages/adaptdl_sched/policy/pollux.py", line 191, in optimize
    problem = Problem(list(jobs.values()), list(nodes.values()) +
  File "/usr/local/lib/python3.8/site-packages/adaptdl_sched/policy/pollux.py", line 275, in __init__
    self._max_replicas[j, n] = min(
  File "/usr/local/lib/python3.8/site-packages/adaptdl_sched/policy/pollux.py", line 276, in <genexpr>
    self._get_avail_resource(
  File "/usr/local/lib/python3.8/site-packages/adaptdl_sched/policy/pollux.py", line 299, in _get_avail_resource
    assert resource >= 0
AssertionError
```
The issue happens because a `None` pod label qualifier is used to include all pods instead of an empty string `""`. This causes the code to always assume all nodes are available (because `None` returns no pods) and it assigns the first one to *every* incoming job. This bug also affects preemptible jobs but without any visible implications because the allocation gets fixed by a later full allocation cycle. 

With the fix, every new job gets the next available node.
