### PR TITLE
Disable immediate allocation for NP jobs

### DIFF
--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -62,7 +62,7 @@ class AdaptDLAllocator(object):
                     # We only consider newly-added preemptible jobs
                     # because this allocation may not be final.
                     if (event["type"] == "ADDED" and
-                        event["object"]["spec"]["preemptible"]):
+                            event["object"]["spec"]["preemptible"]):
                         async with self._lock:
                             await self._allocate_one(event)
 

--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -59,7 +59,10 @@ class AdaptDLAllocator(object):
                 async for event in watch.stream(
                         self._objs_api.list_namespaced_custom_object,
                         *self._custom_resource, timeout_seconds=60):
-                    if event["type"] == "ADDED":  # there is a n arriving job
+                    # We only consider newly-added preemptible jobs
+                    # because this allocation may not be final.
+                    if (event["type"] == "ADDED" and
+                        event["object"]["spec"]["preemptible"]):
                         async with self._lock:
                             await self._allocate_one(event)
 


### PR DESCRIPTION
`_allocate_one` looks at existing pods to look for an available node for the newly-added job. There could be a situation where two consecutive non-preemptible jobs can both get the same allocation because the earlier job haven't spawned any replica pods yet. This can trigger a reallocation for the second non-preemptible job at a later full allocation cycle which crashes the allocator because it violates the basic assumption about pinned non-preemptible jobs. This fix only allows this optimization for preemptible jobs. 