### PR TITLE
Handle default case of spec.preemptible

### DIFF
--- a/sched/adaptdl_sched/allocator.py
+++ b/sched/adaptdl_sched/allocator.py
@@ -62,7 +62,7 @@ class AdaptDLAllocator(object):
                     # We only consider newly-added preemptible jobs
                     # because this allocation may not be final.
                     if (event["type"] == "ADDED" and
-                            event["object"]["spec"]["preemptible"]):
+                            event["object"]["spec"].get("preemptible", True)):
                         async with self._lock:
                             await self._allocate_one(event)
 


### PR DESCRIPTION
AdaptDLJob is preemptible by default (when not specified in the spec)