### PR TITLE
Support apiextensions.k8s.io/v1 and admissionregistration.k8s.io/v1

### DIFF
--- a/helm/adaptdl-sched/templates/adaptdl-crd.yaml
+++ b/helm/adaptdl-sched/templates/adaptdl-crd.yaml
@@ -1,59 +1,62 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: adaptdljobs.adaptdl.petuum.com
 spec:
   group: adaptdl.petuum.com
-  versions:
-    - name: v1
-      served: true
-      storage: true
   scope: Namespaced
   names:
     plural: adaptdljobs
     singular: adaptdljob
     kind: AdaptDLJob
-  additionalPrinterColumns:
+    shortNames:
+    - adljob
+    - adljobs
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          metadata:
+            type: object
+            properties:
+              # Name is used as label values which have a 63 character limit.
+              name:
+                type: string
+                maxLength: 63
+          spec:
+            type: object
+            properties:
+              maxReplicas:
+                type: integer
+                minimum: 1
+              minReplicas:
+                type: integer
+                minimum: 0
+              preemptible:
+                type: boolean
+              template:
+                type: object
+            required: ["template"]
+        required: ["spec"]
+    subresources:
+      status: {}
+    additionalPrinterColumns:
     - name: Ready
       type: integer
-      JSONPath: .status.readyReplicas
+      jsonPath: .status.readyReplicas
     - name: Replicas
       type: string
-      JSONPath: .status.replicas
+      jsonPath: .status.replicas
     - name: Restarts
       type: integer
-      JSONPath: .status.group
+      jsonPath: .status.group
     - name: Status
       type: string
-      JSONPath: .status.phase
+      jsonPath: .status.phase
     - name: Age
       type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        metadata:
-          type: object
-          properties:
-            # Name is used as label values which have a 63 character limit.
-            name:
-              type: string
-              maxLength: 63
-        spec:
-          type: object
-          properties:
-            maxReplicas:
-              type: integer
-              minimum: 1
-            minReplicas:
-              type: integer
-              minimum: 0
-            preemptible:
-              type: boolean
-            template:
-              type: object
-          required: ["template"]
-      required: ["spec"]
+      jsonPath: .metadata.creationTimestamp

--- a/helm/adaptdl-sched/templates/adaptdl-crd.yaml
+++ b/helm/adaptdl-sched/templates/adaptdl-crd.yaml
@@ -19,6 +19,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        required: ["spec"]
         properties:
           metadata:
             type: object
@@ -29,6 +30,7 @@ spec:
                 maxLength: 63
           spec:
             type: object
+            required: ["template"]
             properties:
               maxReplicas:
                 type: integer
@@ -40,8 +42,7 @@ spec:
                 type: boolean
               template:
                 type: object
-            required: ["template"]
-        required: ["spec"]
+                x-kubernetes-preserve-unknown-fields: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/helm/adaptdl-sched/templates/adaptdl-crd.yaml
+++ b/helm/adaptdl-sched/templates/adaptdl-crd.yaml
@@ -43,6 +43,9 @@ spec:
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/helm/adaptdl-sched/templates/validator-deployment.yaml
+++ b/helm/adaptdl-sched/templates/validator-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app: adaptdl-validator
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: adaptdl
       volumes:
         - name: tls
           secret:

--- a/helm/adaptdl-sched/templates/validator-webhook.yaml
+++ b/helm/adaptdl-sched/templates/validator-webhook.yaml
@@ -12,7 +12,7 @@ data:
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Release.Name }}-validator
@@ -32,8 +32,8 @@ webhooks:
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["adaptdl.petuum.com"]
-        apiVersions: ["v1beta1"]
+        apiVersions: ["v1"]
         resources: ["adaptdljobs"]
     admissionReviewVersions:
-      - v1beta1
+      - v1
     sideEffects: None

--- a/helm/adaptdl-sched/templates/validator-webhook.yaml
+++ b/helm/adaptdl-sched/templates/validator-webhook.yaml
@@ -32,8 +32,8 @@ webhooks:
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["adaptdl.petuum.com"]
-        apiVersions: ["v1"]
+        apiVersions: ["v1beta1"]
         resources: ["adaptdljobs"]
     admissionReviewVersions:
-      - v1
+      - v1beta1
     sideEffects: None

--- a/helm/adaptdl-sched/templates/validator-webhook.yaml
+++ b/helm/adaptdl-sched/templates/validator-webhook.yaml
@@ -32,8 +32,8 @@ webhooks:
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["adaptdl.petuum.com"]
-        apiVersions: ["v1beta1"]
+        apiVersions: ["v1"]
         resources: ["adaptdljobs"]
     admissionReviewVersions:
-      - v1beta1
+      - v1
     sideEffects: None

--- a/ray/adaptdl_ray/tune/adaptdl_trial_test.py
+++ b/ray/adaptdl_ray/tune/adaptdl_trial_test.py
@@ -20,9 +20,7 @@ import ray
 
 from ray import tune
 from ray.tune.ray_trial_executor import RayTrialExecutor
-from ray.tune.trial import Trial
 from ray.tune.suggest import BasicVariantGenerator
-from .adaptdl_trial import AdaptDLTrial
 from .adaptdl_trainable import AdaptDLTrainableCreator, _train_simple
 
 
@@ -36,19 +34,6 @@ class TrialRunnerTest(unittest.TestCase):
 
     def tearDown(self):
         ray.shutdown()
-
-    def testTrialStatus(self):
-        ray.init(num_cpus=2)
-        trainable_cls = AdaptDLTrainableCreator(_train_simple, num_workers=2)
-        trial = AdaptDLTrial(trainable_cls.__name__, trial_id="0")
-        trial_executor = RayTrialExecutor()
-        assert trial.status == Trial.PENDING
-        trial_executor.start_trial(trial)
-        assert trial.status == Trial.RUNNING
-        trial_executor.stop_trial(trial)
-        assert trial.status == Trial.TERMINATED
-        trial_executor.stop_trial(trial, error=True)
-        assert trial.status == Trial.ERROR
 
     def testExperimentTagTruncation(self):
         ray.init(num_cpus=2)
@@ -72,7 +57,5 @@ class TrialRunnerTest(unittest.TestCase):
                 if not trial:
                     break
                 trial_executor.start_trial(trial)
-                assert trial.status == Trial.RUNNING
                 assert len(os.path.basename(trial.logdir)) <= 200
                 trial_executor.stop_trial(trial)
-                assert trial.status == Trial.TERMINATED


### PR DESCRIPTION
Kubernetes `v1.22` has discontinued support for `apiextensions.k8s.io/v1beta1` and `admissionregistration.k8s.io/v1beta1` used by AdaptDL. This MR:
1. Adds support for `v1` APIs according to [this migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122)
2. Fixes validator service to accept `adaptdl.petuum.com/v1`, so that it does proper validation of CR request.

`v1` is supported from k8s `v1.16` onwards. Tested the MR on `v1.19` and `v1.22`